### PR TITLE
Add a new API plugin for AGR

### DIFF
--- a/plugins/agr/manifest.json
+++ b/plugins/agr/manifest.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.1",
+  "__metadata__": {
+    "url": "https://www.alliancegenome.org/downloads",
+    "license_url": "https://creativecommons.org/licenses/by/4.0/",
+    "license": "CC BY 4.0"
+  },
+  "dumper": {
+    "data_url": "https://download.alliancegenome.org/4.0.0/DISEASE-ALLIANCE/COMBINED/DISEASE-ALLIANCE_COMBINED_47.tsv.gz",
+    "uncompress": false,
+    "release": "version:get_release"
+  },
+  "uploader": {
+    "parser": "parser:load_data",
+    "on_duplicates": "merge"
+  }
+}

--- a/plugins/agr/parser.py
+++ b/plugins/agr/parser.py
@@ -1,0 +1,66 @@
+import re
+import os.path
+import json
+from collections import defaultdict
+from biothings.utils.common import open_anyfile
+from biothings.utils.dataload import dict_sweep
+
+SKIP_ROWS = 15   # number of rows to skip
+HEADER_ROW = 15  # zero-indexed header row
+DESIRED_OBJECT_TYPES = [
+    "gene"
+]
+
+def load_data(data_folder):
+    agr_file = os.path.join(data_folder, "DISEASE-ALLIANCE_COMBINED_47.tsv.gz")
+    i = -1
+    entries = defaultdict(dict)
+
+
+    with open_anyfile(agr_file, "r") as file:
+        for line in file:
+            i += 1
+            if i < SKIP_ROWS:
+                continue
+            elif i == HEADER_ROW:
+                # convert headers to lowercase, underscore_delimited
+                header = [
+                    re.sub(r"(.)([A-Z])", r"\1_\2", colname).lower()
+                    for colname in
+                    line.rstrip('\n').split('\t')
+                ]
+                continue
+
+            row = line.rstrip('\n').split('\t')
+            if row[2] not in DESIRED_OBJECT_TYPES:
+                continue
+
+            # Comments below correspond to original column names
+            entries[row[3]]["_id"] = row[3]  # DBObjectID
+            if "agr" not in entries[row[3]]:
+                entries[row[3]]["agr"] = {}
+            entry = entries[row[3]]["agr"]
+            entry[header[0]] = row[0]        # Taxon
+            entry[header[1]] = row[1]        # SpeciesName
+            entry["symbol"] = row[4]         # originally DBObjectSymbol
+
+            if row[5] not in entry:
+                entry[row[5]] = []
+
+            entry[row[5]].append(dict_sweep({  # AssociationType
+                "doid": row[6],                # DOID
+                "term_name": row[7],           # DOtermName
+                header[8]: list(
+                    filter(len, row[8].split("|"))
+                ),                             # WithOrthologs
+                "inferred_from_id": row[9],    # InferredFromID
+                header[10]: row[10],           # InferredFromSymbol
+                header[11]: row[11],           # EvidenceCode
+                header[12]: row[12],           # EvidenceCodeName
+                header[13]: row[13],           # Reference
+                header[14]: row[14],           # Date
+                header[15]: row[15]            # Source
+            }, remove_invalid_list=True))
+
+    for doc in entries.values():
+        yield dict_sweep(doc, remove_invalid_list=True)

--- a/plugins/agr/version.py
+++ b/plugins/agr/version.py
@@ -1,0 +1,3 @@
+def get_release(self):
+    # hard-coded due to hard-coded file download
+    return "4.0.0"


### PR DESCRIPTION
This PR addresses #28 by adding a new manifest plugin.

<details>
<summary>Example output, click to expand</summary>

```JSON
{
  "_id": "WB:WBGene00003163",
  "agr": {
    "taxon": "NCBITaxon:6239",
    "species_name": "Caenorhabditis elegans",
    "symbol": "mdl-1",
    "is_implicated_in": [
      {
        "doid": "DOID:14330",
        "term_name": "Parkinson's disease",
        "evidence_code": "ECO:0000270",
        "evidence_code_name": "expression pattern evidence used in manual assertion",
        "reference": "PMID:20091141",
        "date": "20140106",
        "source": "WB"
      },
      {
        "doid": "DOID:14330",
        "term_name": "Parkinson's disease",
        "evidence_code": "ECO:0007013",
        "evidence_code_name": "combinatorial experimental and author inference evidence used in manual assertion",
        "reference": "PMID:20091141",
        "date": "20140106",
        "source": "WB"
      }
    ],
    "implicated_via_orthology": [
      {
        "doid": "DOID:10283",
        "term_name": "prostate cancer",
        "with_orthologs": [
          "HGNC:7534"
        ],
        "evidence_code": "ECO:0000501",
        "evidence_code_name": "evidence used in automatic assertion",
        "reference": "MGI:6194238",
        "date": "20210326",
        "source": "Alliance"
      },
      {
        "doid": "DOID:3512",
        "term_name": "neurofibrosarcoma",
        "with_orthologs": [
          "HGNC:7534"
        ],
        "evidence_code": "ECO:0000501",
        "evidence_code_name": "evidence used in automatic assertion",
        "reference": "MGI:6194238",
        "date": "20210326",
        "source": "Alliance"
      },
      {
        "doid": "DOID:5041",
        "term_name": "esophageal cancer",
        "with_orthologs": [
          "RGD:3128"
        ],
        "evidence_code": "ECO:0000501",
        "evidence_code_name": "evidence used in automatic assertion",
        "reference": "MGI:6194238",
        "date": "20210326",
        "source": "Alliance"
      },
      {
        "doid": "DOID:3458",
        "term_name": "breast adenocarcinoma",
        "with_orthologs": [
          "RGD:3128"
        ],
        "evidence_code": "ECO:0000501",
        "evidence_code_name": "evidence used in automatic assertion",
        "reference": "MGI:6194238",
        "date": "20210326",
        "source": "Alliance"
      }
    ]
  }
}
```
</details>