### PR TITLE
change the `leaf_umls` structure

### DIFF
--- a/web/handlers/ngd.py
+++ b/web/handlers/ngd.py
@@ -172,7 +172,7 @@ class SemmedNGDHandler(BaseAPIHandler):
             result["umls"] = [term.root for term in term_pair]
             result["expand"] = expansion_mode.name.lower()
             if expansion_mode is not ExpansionMode.NIL:
-                result["leaf_umls"] = [{term.root: term.leaves} for term in term_pair if term.has_expanded]
+                result["leaf_umls"] = {term.root: term.leaves for term in term_pair if term.has_expanded}
 
             self.finish(result)
             return


### PR DESCRIPTION
This PR simply changes the `leaf_umls` structure from a list of single-element dictionaries to a combined dictionary.

Previously:

```python
"leaf_umls": [
  {
    "C0599779": [
      "C1518385",
      "..."
    ]
  },
  {
    "C0683949": [
      "C0599779",
      "..."
    ]
  }
]
```

Now:

```python
"leaf_umls": {
  "C0599779": [
    "C1518385",
    "..."
  ],
  "C0683949": [
    "C0599779",
    "..."
  ]
}
```