### PR TITLE
First implementation to Issue#88

### DIFF
--- a/config_web/pfocr.py
+++ b/config_web/pfocr.py
@@ -10,7 +10,8 @@ API_VERSION = ''
 
 QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
 QUERY_KWARGS['POST'].update({
-    'minimum_should_match': {'type': int}
+    'minimum_should_match': {'type': int},
+    'operator': {'type': str}
 })
 
 ES_QUERY_BUILDER = "web.query_builders.PfocrQueryBuilder"

--- a/config_web/pfocr.py
+++ b/config_web/pfocr.py
@@ -1,3 +1,5 @@
+import copy
+from biothings.web.settings.default import QUERY_KWARGS
 
 ES_HOST = 'localhost:9200'
 ES_INDEX = 'pending-pfocr'
@@ -5,3 +7,15 @@ ES_DOC_TYPE = 'geneset'
 
 API_PREFIX = 'pfocr'
 API_VERSION = ''
+
+QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
+QUERY_KWARGS['POST'].update({
+    'minimum_should_match': {'type': int}
+})
+
+ES_QUERY_BUILDER = "web.query_builders.PfocrQueryBuilder"
+# from biothings.api web/settings/default.py we have
+# ES_QUERY_PIPELINE = 'biothings.web.query.AsyncESQueryPipeline'
+# ES_QUERY_BUILDER = 'biothings.web.query.ESQueryBuilder'
+# ES_QUERY_BACKEND = 'biothings.web.query.AsyncESQueryBackend'
+# ES_RESULT_TRANSFORM = 'biothings.web.query.ESResultFormatter'

--- a/web/query_builders/__init__.py
+++ b/web/query_builders/__init__.py
@@ -1,0 +1,1 @@
+from .pfocr import PfocrQueryBuilder

--- a/web/query_builders/pfocr.py
+++ b/web/query_builders/pfocr.py
@@ -1,0 +1,21 @@
+from biothings.web.query import ESQueryBuilder
+from elasticsearch_dsl.query import MultiMatch
+from elasticsearch_dsl import Search
+
+
+class PfocrQueryBuilder(ESQueryBuilder):
+    def default_match_query(self, q, scopes, options):
+        # E.g. q = "5601 5595 10189 10333"
+        # E.g. scopes = "associatedWith.mentions.genes.ncbigene"
+        assert isinstance(q, str)
+        assert isinstance(scopes, (str, list)) and scopes
+
+        operator = "OR"  # defaults to "OR"; should be "OR" here
+        lenient = True  # defaults to False; should be True here
+        analyzer = options.analyzer  # should be "whitespace"
+        minimum_should_match = options.minimum_should_match  # should be a positive integer
+
+        multi_match = MultiMatch(query=q, fields=scopes, operator=operator, lenient=lenient, analyzer=analyzer,
+                                 minimum_should_match=minimum_should_match)
+        search = Search().query(multi_match)
+        return search


### PR DESCRIPTION
This PR is a first implementation to [Issue#88](https://github.com/biothings/pending.api/issues/88).

Sample python code for POST queries:

```python
import requests

url = 'https://biothings.ncats.io/pfocr'  # PROD
# url = 'http://localhost:8000/pfocr/query'  # Testing

data = {
    "q": ["5601 5595 10189 10333", "10971 581"],  
    "scopes": "associatedWith.mentions.genes.ncbigene", 
    "fields": ["_id", "associatedWith.mentions.genes.ncbigene"],
    "operator": "OR",  # necessary, to override the default "AND"
    "analyzer": "whitespace",  # necessary, otherwise we cannot parse "q"
    "minimum_should_match": 2,  # necessary because we don't such a parameter by default
    "size":10
}

response = requests.post(url, json=data)
print(response.json())
```

Response: <details><summary>CLICK ME</summary>

```json
[
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC1175050__ar1784-1.jpg",
    "_score": 14.880091,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10189",
            "10333",
            "1432",
            "2353",
            "2354",
            "2355",
            "3552",
            "3553",
            "3592",
            "3593",
            "3654",
            "3725",
            "3726",
            "3727",
            "4214",
            "4615",
            "4790",
            "51284",
            "51311",
            "54106",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5971",
            "6300",
            "7096",
            "7097",
            "7098",
            "7099",
            "7100",
            "7124",
            "7189",
            "8061",
            "81793",
            "958",
            "959"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC1782589__imm0113-0281-f3.jpg",
    "_score": 10.675004,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10189",
            "116379",
            "1432",
            "146850",
            "23533",
            "30849",
            "3586",
            "3588",
            "3716",
            "3717",
            "3718",
            "50616",
            "5290",
            "5291",
            "5293",
            "5294",
            "53832",
            "55801",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5777",
            "6300",
            "6772",
            "6773",
            "6774",
            "6775",
            "6776",
            "6777",
            "6778",
            "7297",
            "8503",
            "8660"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC3049118__2042-6410-2-2-6.jpg",
    "_score": 10.649014,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10189",
            "10524",
            "10787",
            "113026",
            "1233",
            "1432",
            "23236",
            "2487",
            "3250",
            "3552",
            "3553",
            "391",
            "4023",
            "51196",
            "5330",
            "5331",
            "5332",
            "5333",
            "5335",
            "5336",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5606",
            "5879",
            "5880",
            "5881",
            "613",
            "6300",
            "6387",
            "6932",
            "759",
            "761",
            "81579",
            "84812",
            "89869",
            "9532"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC3317229__JST2012-463617.004.jpg",
    "_score": 10.649014,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10189",
            "1050",
            "1051",
            "1052",
            "1053",
            "1054",
            "10926",
            "1432",
            "23542",
            "23643",
            "23683",
            "3552",
            "3553",
            "3606",
            "3664",
            "3726",
            "3727",
            "4149",
            "4215",
            "4216",
            "4294",
            "5008",
            "5345",
            "5578",
            "5579",
            "5580",
            "5581",
            "5582",
            "5583",
            "5584",
            "5588",
            "5590",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5606",
            "5607",
            "5608",
            "5609",
            "6300",
            "6416",
            "6714",
            "7867",
            "8550",
            "9043",
            "9261",
            "929"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC6639196__CAM4-8-3748-g004.jpg",
    "_score": 10.586578,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "10143",
            "10189",
            "11156",
            "1432",
            "207",
            "208",
            "2475",
            "328",
            "3934",
            "4154",
            "4316",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "6300"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC5700962__41598_2017_16286_Fig7_HTML.jpg",
    "_score": 10.452475,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10097",
            "10189",
            "10563",
            "107",
            "108",
            "109",
            "10913",
            "111",
            "112",
            "113",
            "114",
            "115",
            "131578",
            "1432",
            "183",
            "1896",
            "196883",
            "2022",
            "2056",
            "2314",
            "2919",
            "2920",
            "2921",
            "3576",
            "3604",
            "3627",
            "3815",
            "3952",
            "3953",
            "3977",
            "4050",
            "4233",
            "4283",
            "5196",
            "5473",
            "5566",
            "5567",
            "5568",
            "5573",
            "5575",
            "5576",
            "5577",
            "55811",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5617",
            "5900",
            "6300",
            "6372",
            "6373",
            "6374",
            "6387",
            "650",
            "6772",
            "6773",
            "6774",
            "6775",
            "6776",
            "6777",
            "6778",
            "7173",
            "8202",
            "8725",
            "8879",
            "9547"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC5706558__nihms882784f8.jpg",
    "_score": 10.233295,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10189",
            "10298",
            "10316",
            "10458",
            "1432",
            "2147",
            "23209",
            "2934",
            "29984",
            "324",
            "3265",
            "345456",
            "3630",
            "3664",
            "375189",
            "3845",
            "391",
            "3984",
            "4125",
            "4893",
            "5058",
            "5062",
            "5063",
            "50649",
            "5216",
            "5217",
            "55740",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5604",
            "5605",
            "56924",
            "57144",
            "5747",
            "58",
            "5829",
            "5879",
            "5880",
            "5881",
            "59",
            "60",
            "6093",
            "6300",
            "70",
            "71",
            "7124",
            "72",
            "7414",
            "788",
            "81",
            "87",
            "88",
            "89",
            "8936",
            "8976",
            "9475"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC5501134__ktib-05-02-1331155-g005.jpg",
    "_score": 8.171674,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "1003",
            "1015",
            "10189",
            "2277",
            "2321",
            "2324",
            "29984",
            "3265",
            "369",
            "3791",
            "382",
            "3845",
            "387",
            "391",
            "4893",
            "5228",
            "54538",
            "5594",
            "5595",
            "5604",
            "5605",
            "58",
            "5879",
            "5880",
            "5881",
            "5894",
            "59",
            "60",
            "6091",
            "6586",
            "6714",
            "673",
            "70",
            "71",
            "72",
            "7422",
            "7423",
            "7424",
            "9353"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC4666791__nihms-726155-f0001.jpg",
    "_score": 8.096166,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10333",
            "10379",
            "2353",
            "2354",
            "2355",
            "3439",
            "3440",
            "3441",
            "3442",
            "3443",
            "3444",
            "3445",
            "3446",
            "3447",
            "3448",
            "3449",
            "3451",
            "3452",
            "3454",
            "3455",
            "3456",
            "3467",
            "3551",
            "3569",
            "3627",
            "3661",
            "3665",
            "3725",
            "3726",
            "3727",
            "4118",
            "4615",
            "4790",
            "4791",
            "51135",
            "51284",
            "51311",
            "54106",
            "5594",
            "5595",
            "5599",
            "5601",
            "5602",
            "56832",
            "5966",
            "5970",
            "5971",
            "6352",
            "6772",
            "6773",
            "6774",
            "7096",
            "7097",
            "7098",
            "7099",
            "7100",
            "7124",
            "7187",
            "7189",
            "7297",
            "8061",
            "81793",
            "8195",
            "8517"
          ]
        }
      }
    }
  },
  {
    "query": "5601 5595 10189 10333",
    "_id": "PMC1087506__1465-9921-6-26-8.jpg",
    "_score": 8.096166,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "1025",
            "10333",
            "1147",
            "1432",
            "2353",
            "3551",
            "3554",
            "3654",
            "3725",
            "4615",
            "4790",
            "4791",
            "51135",
            "51284",
            "51311",
            "54106",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "5966",
            "5970",
            "5971",
            "6300",
            "7096",
            "7097",
            "7098",
            "7099",
            "7100",
            "7132",
            "7186",
            "7189",
            "81793",
            "8517",
            "8717"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC2744676__1478-811X-7-20-2.jpg",
    "_score": 8.331091,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "1017",
            "1018",
            "1019",
            "1020",
            "1021",
            "1022",
            "1024",
            "1025",
            "10971",
            "144455",
            "1869",
            "1870",
            "1871",
            "1874",
            "1875",
            "1876",
            "1950",
            "1956",
            "207",
            "208",
            "2261",
            "23097",
            "23552",
            "23683",
            "2475",
            "3265",
            "331",
            "332",
            "344387",
            "369",
            "3845",
            "4790",
            "4893",
            "51265",
            "5127",
            "5128",
            "5129",
            "51755",
            "5218",
            "5266",
            "54205",
            "5566",
            "5567",
            "5568",
            "5573",
            "5575",
            "5576",
            "5577",
            "5578",
            "5579",
            "5580",
            "5581",
            "5582",
            "5583",
            "5584",
            "5588",
            "5590",
            "5604",
            "5605",
            "572",
            "581",
            "5894",
            "6198",
            "6199",
            "65061",
            "673",
            "6792",
            "728642",
            "79733",
            "8558",
            "8621",
            "8814",
            "8999",
            "983",
            "984"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC3304298__fnmol-05-00033-g0001.jpg",
    "_score": 8.331091,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "10018",
            "10316",
            "10971",
            "1147",
            "117145",
            "1326",
            "146850",
            "200576",
            "207",
            "208",
            "23239",
            "23533",
            "2475",
            "253260",
            "2549",
            "27250",
            "2931",
            "2932",
            "30849",
            "331",
            "3611",
            "3667",
            "3716",
            "4067",
            "4193",
            "4283",
            "4661",
            "4846",
            "51083",
            "5163",
            "5208",
            "5290",
            "5291",
            "5293",
            "5294",
            "572",
            "5728",
            "5747",
            "57521",
            "581",
            "595",
            "596",
            "613",
            "6198",
            "6199",
            "64223",
            "6850",
            "7157",
            "7248",
            "7249",
            "79109",
            "84335",
            "8503",
            "930",
            "9846",
            "9882"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC6041399__fphar-09-00715-g0001.jpg",
    "_score": 8.331091,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "100132074",
            "10018",
            "10971",
            "1843",
            "207",
            "208",
            "2308",
            "2309",
            "2353",
            "2354",
            "2355",
            "355",
            "3725",
            "3726",
            "3727",
            "4217",
            "4303",
            "4842",
            "5599",
            "5601",
            "5602",
            "5609",
            "572",
            "581",
            "596",
            "598",
            "6416",
            "8061",
            "8739",
            "9479"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC6162501__cancers-10-00297-g002.jpg",
    "_score": 8.331091,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "1026",
            "1029",
            "10971",
            "1647",
            "1869",
            "2073",
            "27113",
            "355",
            "3845",
            "4193",
            "4194",
            "5054",
            "5366",
            "5371",
            "55367",
            "581",
            "7157",
            "7508",
            "7832"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC4562315__nihms-717918-f0003.jpg",
    "_score": 8.207007,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10971",
            "11211",
            "1499",
            "1855",
            "1856",
            "1857",
            "25",
            "2535",
            "26524",
            "27113",
            "2931",
            "2932",
            "324",
            "4485",
            "472",
            "51384",
            "54361",
            "55249",
            "5599",
            "5601",
            "5602",
            "581",
            "7161",
            "7299",
            "7306",
            "7471",
            "7472",
            "7473",
            "7474",
            "7475",
            "7476",
            "7477",
            "7478",
            "7479",
            "7480",
            "7481",
            "7482",
            "7483",
            "7484",
            "7855",
            "7976",
            "80326",
            "81029",
            "8312",
            "8313",
            "8321",
            "8322",
            "8323",
            "8324",
            "8325",
            "8326",
            "8549",
            "8945",
            "89780",
            "9113"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC2937064__nihms218132f4.jpg",
    "_score": 8.207007,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "10018",
            "10971",
            "1647",
            "207",
            "208",
            "2475",
            "3479",
            "3486",
            "356",
            "3667",
            "472",
            "50484",
            "581",
            "6767",
            "7157",
            "7508",
            "8471",
            "8660",
            "8795",
            "898",
            "9134",
            "940"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC6174659__GE-7-387-g001.jpg",
    "_score": 8.157711,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "1026",
            "10971",
            "1435",
            "1436",
            "1647",
            "1950",
            "1956",
            "203074",
            "2765",
            "3486",
            "355",
            "3623",
            "3625",
            "3811",
            "4134",
            "4193",
            "467",
            "472",
            "5111",
            "575",
            "581",
            "596",
            "64393",
            "6534",
            "6767",
            "7039",
            "7157",
            "8061",
            "8493",
            "8793",
            "8794",
            "8795"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC4629535__nihms703214f4.jpg",
    "_score": 8.157711,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "10013",
            "10014",
            "1017",
            "1018",
            "1019",
            "1020",
            "1021",
            "1022",
            "1024",
            "1025",
            "10971",
            "11200",
            "1432",
            "1499",
            "1869",
            "2033",
            "207",
            "208",
            "22933",
            "23097",
            "23408",
            "23409",
            "23410",
            "23411",
            "23552",
            "27113",
            "2765",
            "28996",
            "3065",
            "3066",
            "332",
            "344387",
            "355",
            "4193",
            "472",
            "51265",
            "5127",
            "5128",
            "5129",
            "51547",
            "51548",
            "51564",
            "51755",
            "5218",
            "5366",
            "53947",
            "54205",
            "545",
            "55332",
            "55367",
            "55869",
            "5594",
            "5595",
            "5599",
            "5600",
            "5601",
            "5602",
            "5603",
            "57103",
            "57152",
            "5728",
            "581",
            "596",
            "6300",
            "64065",
            "65061",
            "6591",
            "672",
            "6792",
            "7157",
            "7161",
            "728642",
            "79885",
            "83933",
            "8558",
            "8621",
            "8795",
            "8797",
            "8814",
            "8841",
            "8850",
            "8999",
            "9049",
            "9734",
            "9759",
            "983",
            "984"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC5482974__joces-130-199463-g4.jpg",
    "_score": 8.157711,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "10000",
            "107",
            "108",
            "109",
            "10971",
            "111",
            "112",
            "113",
            "114",
            "115",
            "1950",
            "196883",
            "207",
            "208",
            "23241",
            "23411",
            "2475",
            "253260",
            "472",
            "4790",
            "4921",
            "5464",
            "55811",
            "581",
            "637",
            "64223",
            "6445",
            "6868",
            "7157",
            "780",
            "79109",
            "8743"
          ]
        }
      }
    }
  },
  {
    "query": "10971 581",
    "_id": "PMC6274615__nihms-977307-f0001.jpg",
    "_score": 8.157711,
    "associatedWith": {
      "mentions": {
        "genes": {
          "ncbigene": [
            "1017",
            "1029",
            "10971",
            "11200",
            "25898",
            "3265",
            "3845",
            "4193",
            "4194",
            "4609",
            "472",
            "4893",
            "5054",
            "51512",
            "545",
            "55367",
            "5728",
            "581",
            "6296",
            "637",
            "64065",
            "64326",
            "6767",
            "7157",
            "7249",
            "7456",
            "83666",
            "898",
            "9134"
          ]
        }
      }
    }
  }
]
```

</details>