### PR TITLE
Removing ES query from config_web/semmeddb.py

### DIFF
--- a/config_web/semmeddb.py
+++ b/config_web/semmeddb.py
@@ -57,25 +57,6 @@ _object_field_name = "object.umls"
 # You are free to name it anything, actually.
 _doc_freq_agg_name = "sum_of_predication_counts"
 
-#########################
-# URLSpec kwargs Part 4 #
-#########################
-
-# Get the total number of predications (as the new "total number of documents")
-
-# Suggested by ITRB: read ES_HOST environment variable first which will take precedence, and fall back to localhost if env value is null or empty
-if "ES_HOST" in os.environ:
-    _es_temp_client = Elasticsearch(hosts=[os.environ["ES_HOST"]])
-else:
-    _es_temp_client = Elasticsearch(hosts=[ES_HOST])
-
-_doc_total_search = Search(using=_es_temp_client, index=ES_INDEX).extra(size=0)
-_doc_total_search.aggs.metric(_doc_freq_agg_name, A("sum", field="predication_count"))
-_doc_total_resp = _doc_total_search.execute()
-_doc_total = int(_doc_total_resp["aggregations"][_doc_freq_agg_name]["value"])
-
-_es_temp_client.close()
-
 ##############################
 # URLSpec kwargs composition #
 ##############################
@@ -83,7 +64,6 @@ _es_temp_client.close()
 urlspec_kwargs = dict(subject_field_name=_subject_field_name,
                       object_field_name=_object_field_name,
                       doc_freq_agg_name=_doc_freq_agg_name,
-                      doc_total=_doc_total,
                       term_expansion_service=_term_expansion_service)
 
 APP_LIST = [

--- a/web/handlers/ngd.py
+++ b/web/handlers/ngd.py
@@ -106,8 +106,7 @@ class SemmedNGDHandler(BaseAPIHandler):
             es_index_name=self.biothings.config.ES_INDEX,  # injected by handler's application instance (created by APILauncher)
             subject_field_name=self.subject_field_name,
             object_field_name=self.object_field_name,
-            doc_freq_agg_name=self.doc_freq_agg_name,
-            doc_total=self.doc_total
+            doc_freq_agg_name=self.doc_freq_agg_name
         )
 
         self.ngd_service = NGDService(

--- a/web/handlers/ngd.py
+++ b/web/handlers/ngd.py
@@ -88,14 +88,13 @@ class SemmedNGDHandler(BaseAPIHandler):
     doc_stats_cache = DocStatsCache(unary_capacity=102400, bipartite_capacity=102400)
     ngd_cache = NGDCache(capacity=102400)
 
-    def initialize(self, subject_field_name: str, object_field_name: str, doc_freq_agg_name: str, doc_total: int, term_expansion_service: TermExpansionService):
+    def initialize(self, subject_field_name: str, object_field_name: str, doc_freq_agg_name: str, term_expansion_service: TermExpansionService):
         super().initialize()
 
         # The following 5 arguments are injected from the URLSpec in config_web/<plugin_name>.py
         self.subject_field_name = subject_field_name
         self.object_field_name = object_field_name
         self.doc_freq_agg_name = doc_freq_agg_name
-        self.doc_total = doc_total
         self.term_expansion_service = term_expansion_service
 
     def prepare(self):


### PR DESCRIPTION
This PR removes the ES query for total number of documents from semmeddb's config file, `config_web/semmeddb.py`.

The total number of documents will instead be cached in a `DocStatsCache` instance and referred to by its associated `DocStatsService` instance.