### PR TITLE
fix: :hammer: skip quoted values, handle negative integers

### DIFF
--- a/web/templates/try.html
+++ b/web/templates/try.html
@@ -323,7 +323,11 @@
             string += ":" + obj[string]
           } 
           else if (_.isNumber(obj[string])) {
-            string += ":" + obj[string]
+            if (parseInt(obj[string]) < 0) {
+              string += `:"${obj[string]}"`
+            } else {
+              string += ":" + obj[string]
+            }
           } 
           else if (_.isString(obj[string]) ) {
             let value = self.handleStringValue(obj[string]);
@@ -354,8 +358,9 @@
           //quote spaces
           else if (string.includes(" ")) {
             if (string.includes('"')) {
-              // already quoted string
-              return string
+              console.warn("Skipped value with quotes")
+              console.warn("%c " + string, 'color:pink')
+              return false
             } else {
               return `"${string}"`;
             }


### PR DESCRIPTION
Small change to skip values with quotes as some include quotes in the middle of the value causing invalid query strings.
Quote negative integers to prevent invalid query strings. 