### PR TITLE
Add init.py to clinicaltrials source

### DIFF
--- a/plugins/clinicaltrials_gov/__init__.py
+++ b/plugins/clinicaltrials_gov/__init__.py
@@ -1,0 +1,2 @@
+from .dumper import ClinicalTrialsGovDumper
+from .uploader import ClinicalTrialsGovUploader


### PR DESCRIPTION
Adding __init__.py to the clinicaltrials.gov plugin folder. It's necessary for the plugin to work on pending API hub. 