### PR TITLE
Fix unintended string concatenation

### DIFF
--- a/web/handlers/annotator.py
+++ b/web/handlers/annotator.py
@@ -244,7 +244,8 @@ class Annotator:
             "client": biothings_client.get_client("disease"),
             "fields": [
                 # IDs
-                "disease_ontology.doid" "mondo.mondo",
+                "disease_ontology.doid",
+                "mondo.mondo",
                 "umls.umls",
                 # Names
                 "disease_ontology.name",


### PR DESCRIPTION
Eliminates the unintended string concatenation within the annotator handlers client leveraging the list of disease fields. Prior the field would be a singular field: `disease_ontology.doidmondo.mondo` versus two separate fields: `disease_ontology.doid` and `mondo.mondo`