### PR TITLE
Fda drugs parser update

### DIFF
--- a/config_web/fda_drugs.py
+++ b/config_web/fda_drugs.py
@@ -1,6 +1,6 @@
 ES_HOST = "http://localhost:9200"
 ES_INDEX = "pending-fda_drugs"
-ES_DOC_TYPE = "chemical"
+ES_DOC_TYPE = "drug"
 
 API_PREFIX = "fda_drugs"
 API_VERSION = ""

--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -102,6 +102,7 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
 
             application = applications_content.get(application_number, NULL_APPLICATION)
             application_company = None
+            breakpoint()
             if application.ApplPublicNotes is not None:
                 application_company = application.ApplPublicNotes
             elif application.SponsorName is not None:
@@ -281,8 +282,14 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
 
                 application_number = entry_row[0]
                 application_type = entry_row[1]
+
                 application_publication_notes = str(entry_row[2]).lower()
+                if application_publication_notes == "":
+                    application_publication_notes = None
+
                 sponsor_name = str(entry_row[3]).lower()
+                if sponsor_name == "":
+                    sponsor_name = None
 
                 application_structure = ApplicationsEntry(
                     ApplNo=application_number,

--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -102,7 +102,6 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
 
             application = applications_content.get(application_number, NULL_APPLICATION)
             application_company = None
-            breakpoint()
             if application.ApplPublicNotes is not None:
                 application_company = application.ApplPublicNotes
             elif application.SponsorName is not None:

--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -172,7 +172,10 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
                     reference_drug = bool(reference_drug_index)
 
                 drug_name = str(entry_row[5])
-                active_ingredients = str(entry_row[6]).lower()
+
+                active_ingredient_delimiter = ";"
+                active_ingredients = entry_row[6].split(active_ingredient_delimiter)
+                active_ingredients = [str(ingredient).strip().lower() for ingredient in active_ingredients]
 
                 try:
                     reference_standard_index = int(entry_row[7])

--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -107,7 +107,7 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
             elif application.SponsorName is not None:
                 application_company = application.SponsorName
 
-            unique_id = f"ApplNo-{application_number}-ProductNo-{product_number}"
+            unique_id = f"{application_number}-{product_number}"
 
             grouped_entry = {
                 "unique_id": unique_id,

--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -1,8 +1,8 @@
 """
 Methods for pulling down the FDA Drugs data
-
 """
 
+import json
 from pathlib import Path
 from typing import List, Union
 import urllib.request
@@ -38,7 +38,7 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
     def __init__(self):
         self.SRC_URLS = FDA_DrugDumper.extract_fda_drug_data()
         self.__class__.SRC_URLS = self.SRC_URLS
-        self.grouped_file = "FDA_DRUGS_GROUPING.txt"
+        self.grouped_file = "FDA_DRUGS_GROUPING.json"
 
         super().__init__()
 
@@ -46,6 +46,23 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
         """
         Takes the FDA drug data files pulled down from the source and groups them to form
         one joined file that contains the structure we wish to upload to our index
+
+        The final structure of our file is a collection of row-based entries with these headers:
+
+        {
+            unique_id,
+            application_number,
+            product_number,
+            drug_name,
+            active_ingredients,
+            strength,
+            dosage_form
+            marketing_status,
+            te_code,
+            reference_drug,
+            reference_standard
+        )
+
         """
 
         # Force creation of the to_dump collection
@@ -56,102 +73,173 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
         with zipfile.ZipFile(local_zip_file, "r") as zip_object:
             zip_object.extractall(data_directory)
 
+        unique_entries = set()
+        products_content = self._process_product_file(data_directory=data_directory, unique_entries=unique_entries)
+        marketing_status_content = self._process_marketing_status_file(
+            data_directory=data_directory, unique_entries=unique_entries
+        )
+        te_content = self._process_te_file(data_directory=data_directory, unique_entries=unique_entries)
+
         marketing_status_lookup_file = Path(data_directory).joinpath("MarketingStatus_Lookup.txt")
         marketing_status_lookup_table = self._build_marketing_status_lookup_table(marketing_status_lookup_file)
 
+        group_file_path = Path(data_directory).joinpath(self.grouped_file)
+        join_mapping = []
+        for lookup_key in unique_entries:
+            product = products_content.get(lookup_key, NULL_PRODUCT)
+            marketing_status = marketing_status_content.get(lookup_key, NULL_MARKETING_STATUS)
+            te = te_content.get(lookup_key, NULL_TE)
+
+            marketing_status_value = marketing_status_lookup_table.get(marketing_status.MarketingStatusID, None)
+            unique_id = f"ApplNo-{product.ApplNo}-ProductNo-{product.ProductNo}-{uuid.uuid4().hex}"
+
+            grouped_entry = {
+                "unique_id": unique_id,
+                "application_number": product.ApplNo,
+                "product_number": product.ProductNo,
+                "drug_name": product.DrugName,
+                "active_ingredient": product.ActiveIngredient,
+                "strength": product.Strength,
+                "dosage_form": product.Form,
+                "marketing_status": marketing_status_value,
+                "te_code": te.TECode,
+                "reference_drug": product.ReferenceDrug,
+                "reference_standard": product.ReferenceStandard,
+            }
+            join_mapping.append(grouped_entry)
+
+        with open(group_file_path, "w", encoding="utf-8") as group_handle:
+            json.dump(join_mapping, group_handle, indent=4)
+
+    def _process_product_file(self, data_directory: Path, unique_entries: set) -> dict:
+        """
+        Processes the Product.txt file into a collection of the following structure:
+
+        ApplNo: int
+        ProductNo: int
+        Form: list[str]
+        Strength: list[str]
+        ReferenceDrug: bool
+        DrugName: str
+        ActiveIngredient: str
+        ReferenceStandard: bool
+
+        """
         products_file = Path(data_directory).joinpath("Products.txt")
-        marketing_status_file = Path(data_directory).joinpath("MarketingStatus.txt")
-        te_file = Path(data_directory).joinpath("TE.txt")
-
-        unique_entries = set()
-
         products_content = {}
+        column_delimiter = "\t"
+
         with open(products_file, "r", encoding="utf-8") as product_handle:
             for raw_entry in product_handle.readlines()[1:]:
-                entry_row = raw_entry.strip().split("\t")
+                entry_row = raw_entry.split(column_delimiter)
+                entry_row = [entry.strip() for entry in entry_row]
 
-                application_number = entry_row[0]
-                product_number = entry_row[1]
+                application_number = int(entry_row[0])
+                product_number = int(entry_row[1])
 
-                if len(entry_row) < 8:
-                    reference_standard = None
-                else:
-                    reference_standard = bool(entry_row[7])
+                dosage_delimiter = ";"
+                dosage_forms = entry_row[2].split(dosage_delimiter)
+                dosage_forms = [str(dosage_entry).strip().lower() for dosage_entry in dosage_forms]
+
+                strength_delimiter = ";"
+                strength = entry_row[3].split(strength_delimiter)
+                strength = [str(strength_entry).strip().lower() for strength_entry in strength]
+
+                try:
+                    reference_drug_index = int(entry_row[4])
+                except ValueError:
+                    reference_drug_index = 0
+                finally:
+                    reference_drug = bool(reference_drug_index)
+
+                drug_name = str(entry_row[5])
+                active_ingredients = str(entry_row[6]).lower()
+
+                try:
+                    reference_standard_index = int(entry_row[7])
+                except ValueError:
+                    reference_standard_index = 0
+                finally:
+                    reference_standard = bool(reference_standard_index)
 
                 product_structure = ProductsFileEntry(
                     ApplNo=application_number,
                     ProductNo=product_number,
-                    Form=entry_row[2],
-                    Strength=entry_row[3],
-                    ReferenceDrug=bool(entry_row[4]),
-                    DrugName=entry_row[5],
-                    ActiveIngredient=entry_row[6],
+                    Form=dosage_forms,
+                    Strength=strength,
+                    ReferenceDrug=reference_drug,
+                    DrugName=drug_name,
+                    ActiveIngredient=active_ingredients,
                     ReferenceStandard=reference_standard,
                 )
                 hash_key = hash(application_number) + hash(product_number)
                 products_content[hash_key] = product_structure
                 unique_entries.add(hash_key)
+        return products_content
 
+    def _process_marketing_status_file(self, data_directory: Path, unique_entries: set) -> dict:
+        """
+        Processes the MarketingStatus.txt file into a collection of the following structure:
+
+        MarketingStatusID: int
+        ApplNo: int
+        ProductNo: str
+
+        """
+        marketing_status_file = Path(data_directory).joinpath("MarketingStatus.txt")
         marketing_status_content = {}
+        column_delimiter = "\t"
+
         with open(marketing_status_file, "r", encoding="utf-8") as marketing_handle:
             for raw_entry in marketing_handle.readlines()[1:]:
-                entry_row = raw_entry.strip().split("\t")
+                entry_row = raw_entry.split(column_delimiter)
+                entry_row = [entry.strip() for entry in entry_row]
 
-                application_number = entry_row[1]
-                product_number = entry_row[2]
+                marketing_status_index = int(entry_row[0])
+                application_number = int(entry_row[1])
+                product_number = int(entry_row[2])
                 marketing_status_structure = MarketingStatusEntry(
-                    MarketingStatusID=int(entry_row[0]), ApplNo=application_number, ProductNo=product_number
+                    MarketingStatusID=marketing_status_index, ApplNo=application_number, ProductNo=product_number
                 )
                 hash_key = hash(application_number) + hash(product_number)
                 marketing_status_content[hash_key] = marketing_status_structure
                 unique_entries.add(hash_key)
+        return marketing_status_content
 
+    def _process_te_file(self, data_directory: Path, unique_entries: set) -> dict:
+        """
+        Processes the TE.txt file into a collection of the following structure:
+
+        ApplNo: int
+        ProductNo: int
+        MarketingStatusID: int
+        TECode: str
+
+        """
+        te_file = Path(data_directory).joinpath("TE.txt")
         te_content = {}
+        column_delimiter = "\t"
+
         with open(te_file, "r", encoding="utf-8") as te_handle:
             for raw_entry in te_handle.readlines()[1:]:
-                entry_row = raw_entry.strip().split("\t")
+                entry_row = raw_entry.split(column_delimiter)
+                entry_row = [entry.strip() for entry in entry_row]
 
-                application_number = entry_row[0]
-                product_number = entry_row[1]
-
-                if len(entry_row) < 4:
-                    te_code = None
-                else:
-                    te_code = entry_row[3]
+                application_number = int(entry_row[0])
+                product_number = int(entry_row[1])
+                marketing_status_index = int(entry_row[2])
+                te_code = str(entry_row[3])
 
                 te_status_structure = TEFileEntry(
                     ApplNo=application_number,
                     ProductNo=product_number,
-                    MarketingStatusID=int(entry_row[2]),
+                    MarketingStatusID=marketing_status_index,
                     TECode=te_code,
                 )
                 hash_key = hash(application_number) + hash(product_number)
                 te_content[hash_key] = te_status_structure
                 unique_entries.add(hash_key)
-
-        group_file_path = Path(data_directory).joinpath(self.grouped_file)
-        with open(group_file_path, "w", encoding="utf-8") as group_handle:
-            for lookup_key in unique_entries:
-
-                product = products_content.get(lookup_key, NULL_PRODUCT)
-                marketing_status = marketing_status_content.get(lookup_key, NULL_MARKETING_STATUS)
-                te = te_content.get(lookup_key, NULL_TE)
-
-                marketing_status_value = marketing_status_lookup_table.get(marketing_status.MarketingStatusID, None)
-                unique_id = f"ApplNo-{product.ApplNo}-ProductNo-{product.ProductNo}-{uuid.uuid4().hex}"
-
-                grouped_entry = (
-                    f"{unique_id}\t"
-                    f"{product.DrugName}\t"
-                    f"{product.ActiveIngredient}\t"
-                    f"{product.Strength}\t "
-                    f"{product.Form}\t"
-                    f"{marketing_status_value}\t"
-                    f"{te.TECode}\t"
-                    f"{product.ReferenceDrug}\t"
-                    f"{product.ReferenceStandard}\n"
-                )
-                group_handle.write(grouped_entry)
+        return te_content
 
     @classmethod
     def _build_marketing_status_lookup_table(cls, marketing_status_lookup_file: Union[str, Path]) -> dict:
@@ -169,7 +257,10 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
             file_contents = file_handle.readlines()[1:]
             for entry in file_contents:
                 lookup_contents = entry.split("\t")
-                marketing_status_mapping[int(lookup_contents[0])] = str(lookup_contents[1]).strip()
+                marketing_status_index = int(lookup_contents[0])
+                marketing_status_value = str(lookup_contents[1]).strip().lower()
+
+                marketing_status_mapping[marketing_status_index] = marketing_status_value
         return marketing_status_mapping
 
     @classmethod

--- a/plugins/fda_drugs/file_definitions.py
+++ b/plugins/fda_drugs/file_definitions.py
@@ -15,6 +15,9 @@ Drug Name	Active Ingredients	Strength	Dosage Form/Route	Marketing Status	TE Code
 [5] TE Code -> TE.txt
 [6] RLD -> Products.txt
 [7] RS -> Products.txt
+
+Naming References:
+https://www.fda.gov/drugs/drug-approvals-and-databases/orange-book-data-files
 """
 
 import dataclasses
@@ -28,10 +31,10 @@ class ProductsFileEntry:
     000004  004       SOLUTION/DROPS;OPHTHALMIC 1%       0             PAREDRINE [HYDROXYAMPHETAMINE HYDROBROMIDE] 0
     """
 
-    ApplNo: str
-    ProductNo: str
-    Form: str
-    Strength: str
+    ApplNo: int
+    ProductNo: int
+    Form: list[str]
+    Strength: list[str]
     ReferenceDrug: bool
     DrugName: str
     ActiveIngredient: str
@@ -58,8 +61,8 @@ class TEFileEntry:
     003444  001       1                 AA
     """
 
-    ApplNo: str
-    ProductNo: str
+    ApplNo: int
+    ProductNo: int
     MarketingStatusID: int
     TECode: str
 
@@ -76,7 +79,7 @@ class MarketingStatusEntry:
     """
 
     MarketingStatusID: int
-    ApplNo: str
+    ApplNo: int
     ProductNo: str
 
 

--- a/plugins/fda_drugs/file_definitions.py
+++ b/plugins/fda_drugs/file_definitions.py
@@ -5,16 +5,18 @@ We don't need all of them but for the one's we do we define a file
 structure here to help strictly specify the structure in code
 
 The document we want to construct has the following structure:
-Drug Name	Active Ingredients	Strength	Dosage Form/Route	Marketing Status	TE Code	RLD	RS
 
-[0] Drug Name -> Products.txt
-[1] Active Ingredients -> Products.txt
-[2] Strength -> Products.txt
-[3] Dosage Form/Route  -> Products.txt
-[4] Marketing Status -> [TE.txt, MarketingStatusi.txt] + MarketingStatus_Lookup.txt
-[5] TE Code -> TE.txt
-[6] RLD -> Products.txt
-[7] RS -> Products.txt
+[0]  Application Number -> [Products.txt, TE.txt, MarketingStatus.txt, Applications.txt]
+[1]  Product Number -> [Products.txt, TE.txt, MarketingStatus.txt, Applications.txt]
+[2]  Drug Name -> Products.txt
+[3]  Active Ingredients -> Products.txt
+[4]  Strength -> Products.txt
+[5]  Dosage Form/Route  -> Products.txt
+[6]  Marketing Status -> [TE.txt, MarketingStatus.txt] + MarketingStatus_Lookup.txt
+[7]  Therapeutic Equivalence Code -> TE.txt
+[8]  Reference Level Drug -> Products.txt
+[9]  Reference Standard -> Products.txt
+[10] Company -> Applications.txt 
 
 Naming References:
 https://www.fda.gov/drugs/drug-approvals-and-databases/orange-book-data-files
@@ -31,8 +33,8 @@ class ProductsFileEntry:
     000004  004       SOLUTION/DROPS;OPHTHALMIC 1%       0             PAREDRINE [HYDROXYAMPHETAMINE HYDROBROMIDE] 0
     """
 
-    ApplNo: int
-    ProductNo: int
+    ApplNo: str
+    ProductNo: str
     Form: list[str]
     Strength: list[str]
     ReferenceDrug: bool
@@ -61,8 +63,8 @@ class TEFileEntry:
     003444  001       1                 AA
     """
 
-    ApplNo: int
-    ProductNo: int
+    ApplNo: str
+    ProductNo: str
     MarketingStatusID: int
     TECode: str
 
@@ -79,8 +81,32 @@ class MarketingStatusEntry:
     """
 
     MarketingStatusID: int
-    ApplNo: int
+    ApplNo: str
     ProductNo: str
 
 
 NULL_MARKETING_STATUS = MarketingStatusEntry(MarketingStatusID=None, ApplNo=None, ProductNo=None)
+
+
+@dataclasses.dataclass(frozen=True)
+class ApplicationsEntry:
+    """
+    ==> Applications.txt <==
+    ApplNo	ApplType	ApplPublicNotes	             SponsorName
+    218158	NDA         FORMOSA PHARMACEUTICALS INC
+    218181	ANDA                                     GRAVITI PHARMS
+    218182	ANDA                                     TARO
+    218193	NDA         MYLAN PHARMS INC
+    218194	ANDA                                     AUROBINDO PHARMA
+    218197	NDA         ASTRAZENECA
+    218213	NDA         BRISTOL
+    218221	ANDA                                     BIONPHARMA
+    """
+
+    ApplNo: str
+    ApplTyp: str
+    ApplPublicNotes: str
+    SponsorName: str
+
+
+NULL_APPLICATION = ApplicationsEntry(ApplNo=None, ApplTyp=None, ApplPublicNotes=None, SponsorName=None)

--- a/plugins/fda_drugs/uploader.py
+++ b/plugins/fda_drugs/uploader.py
@@ -46,6 +46,7 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
                     "te_code": entry_map["te_code"],
                     "rld": entry_map["reference_drug"],
                     "rs": entry_map["reference_standard"],
+                    "company": entry_map["company"],
                 }
                 yield document
 
@@ -55,6 +56,8 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
         Elasticsearch mapping for representing the structured FDA drugs data
         Entry Structure:
         {
+            <Application Number>
+            <Product Number>
             <Drug Name>
             <Active Ingredients>
             <Strength>
@@ -63,6 +66,7 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
             <TE Code>
             <RLD>
             <RS>
+            <Company>
         }
         """
         elasticsearch_mapping = {
@@ -76,5 +80,6 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
             "te_code": {"type": "keyword"},
             "rld": {"type": "keyword"},
             "reference_standard": {"type": "keyword"},
+            "company": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
         }
         return elasticsearch_mapping

--- a/plugins/fda_drugs/uploader.py
+++ b/plugins/fda_drugs/uploader.py
@@ -72,7 +72,7 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
         elasticsearch_mapping = {
             "anda": {"type": "keyword"},
             "product_no": {"type": "keyword"},
-            "drug_name": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
+            "drug_name": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer", "copy_to": ["all"]},
             "active_ingredients": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
             "strength": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
             "dosage_form": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},

--- a/plugins/fda_drugs/uploader.py
+++ b/plugins/fda_drugs/uploader.py
@@ -78,8 +78,8 @@ class FDA_DrugUploader(biothings.hub.dataload.uploader.BaseSourceUploader):
             "dosage_form": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
             "marketing_status": {"type": "keyword"},
             "te_code": {"type": "keyword"},
-            "rld": {"type": "keyword"},
-            "reference_standard": {"type": "keyword"},
+            "rld": {"type": "boolean"},
+            "rs": {"type": "boolean"},
             "company": {"type": "keyword", "normalizer": "keyword_lowercase_normalizer"},
         }
         return elasticsearch_mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,3 @@ profile = "black"
 combine_as_imports = true
 line_length = 120
 src_paths = ["."]
-
-[flake8]
-per-file-ignores =
-    tests: S101 # Ignore the usage of "assert" in tests as a security concern for [bandit]
-
-[tool.bandit.assert_used]
-skips = ['*_test.py', '*/test_*.py'] # Ignore the usage of "assert" in tests as a security concern for [bandit]


### PR DESCRIPTION
Plugin Reference: https://github.com/biothings/pending.api/issues/178

Parsing Issues

- [X]     "dosage_form": " SOLUTION/DROPS;OPHTHALMIC", <-- remove whitespaces, and split as a list
- [X]     the object should include appl no as anda field
- [X]     the object should include produce no as product_no field
- [X]     lower case the status string: "marketing_status": "Discontinued",
- [X]     "therapeutic_equivalence": "None" convert "None" to actual None value, we might want to call it te_code as their website calls.
- [X]     how about the rld and rs fields as shown in their website, even though the value is None in this case?
- [X]     I might lowercase all values (e.g. active_ingredients, dosage_form, marketing_status and strength fields), except the drug_name field (which is typically uppercased)
- [X]     I noticed some value of strength can be multiple as well (strength:0.02MG;1MG), so it should split to a list as well
- [X]     Add drug_name to the "default to all" in the mapping, so that this query should work /query?q=kainair.
- [X]     We should also include the company field as shown in their website, if provided in their data files.


Validated against a random subset of the data pulled from the database: [random_sample.json](https://github.com/biothings/pending.api/files/15155292/entry.json)

