### PR TITLE
Ensure that the company field is UPPERCASE

### DIFF
--- a/plugins/fda_drugs/dumper.py
+++ b/plugins/fda_drugs/dumper.py
@@ -285,11 +285,11 @@ class FDA_DrugDumper(biothings.hub.dataload.dumper.LastModifiedHTTPDumper):
                 application_number = entry_row[0]
                 application_type = entry_row[1]
 
-                application_publication_notes = str(entry_row[2]).lower()
+                application_publication_notes = str(entry_row[2]).upper()
                 if application_publication_notes == "":
                     application_publication_notes = None
 
-                sponsor_name = str(entry_row[3]).lower()
+                sponsor_name = str(entry_row[3]).upper()
                 if sponsor_name == "":
                     sponsor_name = None
 


### PR DESCRIPTION
New document structure reference:
```
211094-002  {"_id": "211094-002", "anda": "211094", "product_no": "002", "drug_name": "DASATINIB", "active_ingredients": ["dasatinib"], "strength": ["50mg"], "dosage_form": ["tablet", "oral"], "marketing_status": "none (tentative approval)", "te_code": null, "rld": false, "rs": false, "company": "TEVA PHARMS USA INC"}                                                                              
071168-001  {"_id": "071168-001", "anda": "071168", "product_no": "001", "drug_name": "BUPIVACAINE HYDROCHLORIDE AND EPINEPHRINE", "active_ingredients": ["bupivacaine hydrochloride", "epinephrine"], "strength": ["0.5%", "0.005mg/ml"], "dosage_form": ["injectable", "injection"], "marketing_status": "prescription", "te_code": "AP", "rld": false, "rs": true, "company": "HOSPIRA"}                  
202842-001  {"_id": "202842-001", "anda": "202842", "product_no": "001", "drug_name": "DEXMETHYLPHENIDATE HYDROCHLORIDE", "active_ingredients": ["dexmethylphenidate hydrochloride"], "strength": ["5mg"], "dosage_form": ["capsule, extended release", "oral"], "marketing_status": "prescription", "te_code": "AB", "rld": false, "rs": false, "company": "PAR PHARM INC"}  
...
```