### PR TITLE
Improve performance infra

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -4,7 +4,7 @@
 
 deployment:
   strategyType: Recreate
-  replicaCount: 1
+  replicaCount: 4
 
 image:
   repository: 853771734544.dkr.ecr.us-east-1.amazonaws.com/translator-bte-pending-api
@@ -16,6 +16,12 @@ containers:
   name: pendingapiserver
   es_host: ES_HOST_VALUE
   port: 9000
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 9000
+    initialDelaySeconds: 60
+    periodSeconds: 15
 
 env:
   OPENTELEMETRY_ENABLED_VALUE: True
@@ -83,8 +89,9 @@ affinity:
       topologyKey: "kubernetes.io/hostname"
 resources:
   requests:
-    memory: 42Gi
-    cpu: 8000m
+    memory: 10.5Gi  # 42Gi / 4
+    cpu: 2000m      # 8000m / 4
   limits:
-    memory: 58Gi
-    cpu: 14000m 
+    memory: 14.5Gi  # 58Gi / 4
+    cpu: 3500m      # 14000m / 4
+

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -22,8 +22,8 @@ containers:
       path: /
       port: 9000
     initialDelaySeconds: 10  # The number of seconds to wait after the container has started before performing the first startup probe.
-    periodSeconds: 15  # How often (in seconds) to perform the startup probe.
-    timeoutSeconds: 10  # The number of seconds after which the probe times out.
+    periodSeconds: 5  # How often (in seconds) to perform the startup probe.
+    timeoutSeconds: 3  # The number of seconds after which the probe times out.
     successThreshold: 1  # The number of consecutive successes required to consider the container started successfully.
     failureThreshold: 5  # The number of consecutive failures required to consider the container startup to have failed.
   # To determine when the container is ready to start accepting traffic
@@ -31,9 +31,9 @@ containers:
     httpGet:
       path: /
       port: 9000
-    initialDelaySeconds: 60  #  The number of seconds to wait after the container has started before performing the first readiness probe.
-    periodSeconds: 15  # How often (in seconds) to perform the readiness probe.
-    timeoutSeconds: 10  # The number of seconds after which the probe times out.
+    initialDelaySeconds: 10  #  The number of seconds to wait after the container has started before performing the first readiness probe.
+    periodSeconds: 5  # How often (in seconds) to perform the readiness probe.
+    timeoutSeconds: 3  # The number of seconds after which the probe times out.
     successThreshold: 1  # The number of consecutive successes required to consider the container ready after it has been failing.
     failureThreshold: 3  # The number of consecutive failures required to consider the container not ready.
   # To determine if a container is still running
@@ -41,9 +41,9 @@ containers:
     httpGet:
       path: /
       port: 9000
-    initialDelaySeconds: 60  # The number of seconds to wait after the container has started before performing the first liveness probe.
+    initialDelaySeconds: 30  # The number of seconds to wait after the container has started before performing the first liveness probe.
     periodSeconds: 15  # How often (in seconds) to perform the liveness probe.
-    timeoutSeconds: 10  # The number of seconds after which the probe times out.
+    timeoutSeconds: 3  # The number of seconds after which the probe times out.
     successThreshold: 1  # The number of consecutive successes required to consider the container healthy after it has been failing.
     failureThreshold: 3  # The number of consecutive failures required to consider the container unhealthy and restart it.
 env:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -3,8 +3,16 @@
 # Declare variables to be passed into your templates.
 
 deployment:
-  strategyType: Recreate
   replicaCount: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # This setting ensures that no existing pods are taken down before new ones are up and running.
+      # This configuration guarantees that there will be no downtime during the update.
+      maxUnavailable: 0
+      # This allows Kubernetes to create one additional pod above the desired number of replicas during the update.
+      # It ensures that a new pod is ready before taking an old pod down.
+      maxSurge: 1
 
 image:
   repository: 853771734544.dkr.ecr.us-east-1.amazonaws.com/translator-bte-pending-api

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -4,7 +4,7 @@
 
 deployment:
   strategyType: Recreate
-  replicaCount: 4
+  replicaCount: 2
 
 image:
   repository: 853771734544.dkr.ecr.us-east-1.amazonaws.com/translator-bte-pending-api
@@ -89,9 +89,9 @@ affinity:
       topologyKey: "kubernetes.io/hostname"
 resources:
   requests:
-    memory: 10.5Gi  # 42Gi / 4
-    cpu: 2000m      # 8000m / 4
+    memory: 42Gi
+    cpu: 8000m
   limits:
-    memory: 14.5Gi  # 58Gi / 4
-    cpu: 3500m      # 14000m / 4
+    memory: 58Gi
+    cpu: 14000m 
 

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -33,7 +33,7 @@ containers:
       port: 9000
     initialDelaySeconds: 60  #  The number of seconds to wait after the container has started before performing the first readiness probe.
     periodSeconds: 15  # How often (in seconds) to perform the readiness probe.
-    timeoutSeconds: 1  # The number of seconds after which the probe times out.
+    timeoutSeconds: 10  # The number of seconds after which the probe times out.
     successThreshold: 1  # The number of consecutive successes required to consider the container ready after it has been failing.
     failureThreshold: 3  # The number of consecutive failures required to consider the container not ready.
   # To determine if a container is still running

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -16,13 +16,36 @@ containers:
   name: pendingapiserver
   es_host: ES_HOST_VALUE
   port: 9000
+  # To determine if a container application has started successfully.
+  startupProbe:
+    httpGet:
+      path: /
+      port: 9000
+    initialDelaySeconds: 10  # The number of seconds to wait after the container has started before performing the first startup probe.
+    periodSeconds: 15  # How often (in seconds) to perform the startup probe.
+    timeoutSeconds: 10  # The number of seconds after which the probe times out.
+    successThreshold: 1  # The number of consecutive successes required to consider the container started successfully.
+    failureThreshold: 5  # The number of consecutive failures required to consider the container startup to have failed.
+  # To determine when the container is ready to start accepting traffic
   readinessProbe:
     httpGet:
       path: /
       port: 9000
-    initialDelaySeconds: 60
-    periodSeconds: 15
-
+    initialDelaySeconds: 60  #  The number of seconds to wait after the container has started before performing the first readiness probe.
+    periodSeconds: 15  # How often (in seconds) to perform the readiness probe.
+    timeoutSeconds: 1  # The number of seconds after which the probe times out.
+    successThreshold: 1  # The number of consecutive successes required to consider the container ready after it has been failing.
+    failureThreshold: 3  # The number of consecutive failures required to consider the container not ready.
+  # To determine if a container is still running
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 9000
+    initialDelaySeconds: 60  # The number of seconds to wait after the container has started before performing the first liveness probe.
+    periodSeconds: 15  # How often (in seconds) to perform the liveness probe.
+    timeoutSeconds: 10  # The number of seconds after which the probe times out.
+    successThreshold: 1  # The number of consecutive successes required to consider the container healthy after it has been failing.
+    failureThreshold: 3  # The number of consecutive failures required to consider the container unhealthy and restart it.
 env:
   OPENTELEMETRY_ENABLED_VALUE: True
   #OPENTELEMETRY_JAEGER_HOST: OPENTELEMETRY_JAEGER_HOST_VALUE

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -27,7 +27,7 @@ containers:
   # To determine if a container application has started successfully.
   startupProbe:
     httpGet:
-      path: /
+      path: /rhea/status
       port: 9000
     initialDelaySeconds: 10  # The number of seconds to wait after the container has started before performing the first startup probe.
     periodSeconds: 5  # How often (in seconds) to perform the startup probe.
@@ -37,7 +37,7 @@ containers:
   # To determine when the container is ready to start accepting traffic
   readinessProbe:
     httpGet:
-      path: /
+      path: /rhea/status
       port: 9000
     initialDelaySeconds: 10  #  The number of seconds to wait after the container has started before performing the first readiness probe.
     periodSeconds: 5  # How often (in seconds) to perform the readiness probe.
@@ -47,11 +47,11 @@ containers:
   # To determine if a container is still running
   livenessProbe:
     httpGet:
-      path: /
+      path: /rhea/status
       port: 9000
     initialDelaySeconds: 30  # The number of seconds to wait after the container has started before performing the first liveness probe.
-    periodSeconds: 15  # How often (in seconds) to perform the liveness probe.
-    timeoutSeconds: 3  # The number of seconds after which the probe times out.
+    periodSeconds: 60  # How often (in seconds) to perform the liveness probe.
+    timeoutSeconds: 30  # The number of seconds after which the probe times out.
     successThreshold: 1  # The number of consecutive successes required to consider the container healthy after it has been failing.
     failureThreshold: 3  # The number of consecutive failures required to consider the container unhealthy and restart it.
 env:


### PR DESCRIPTION
# Context
The application is frequently returning HTTP 503.

# Objective
These changes involve adding startup, readiness, and liveness probes to improve the reliability of the application during the deployment process and minimize errors when pods restart.