### PR TITLE
Update release_date for pfocr

### DIFF
--- a/plugins/pfocr/version.py
+++ b/plugins/pfocr/version.py
@@ -1,3 +1,3 @@
 def get_release(self):
-    release_date = "2023-04-01"
+    release_date = "2024-09-01"
     return release_date


### PR DESCRIPTION
Not sure if this is the correct protocol, but this PR updates the release_date for the new pfocr content. Related to this issue: https://github.com/biothings/pending.api/issues/241