### PR TITLE
add plugin for merged rtx-kg2 edges

### DIFF
--- a/plugins/rtx-kg2/parser.py
+++ b/plugins/rtx-kg2/parser.py
@@ -1,0 +1,43 @@
+import json
+
+BUFFER_SIZE = 1024
+
+PUBLICATIONS_FIELD_NAME= 'publications'
+PUBLICATIONS_INFO_FIELD_NAME= 'publications_info'
+PMID_FIELD_NAME= 'pmid'
+
+def flatten_publications(data):
+    pmid_list = data[PUBLICATIONS_FIELD_NAME]
+    publications_info = data[PUBLICATIONS_INFO_FIELD_NAME]
+
+    def extend_pub_info(pmid: str):
+        pub_info = publications_info[pmid]
+        pub_info[PMID_FIELD_NAME] = pmid
+        return pub_info
+
+    return list(map(extend_pub_info, pmid_list))
+
+
+def load_data_file(input_file: str):
+    with open(input_file, encoding="utf-8") as file_handle:
+
+        buffer = []
+
+        for line in file_handle:
+            doc = json.loads(line)
+            buffer.append(doc)
+
+            # make sure _id is a string
+            doc["_id"] = str(doc["id"])
+
+            # flatten nested publication_info field
+            if PUBLICATIONS_FIELD_NAME in doc and PUBLICATIONS_INFO_FIELD_NAME in doc:
+                doc[PUBLICATIONS_INFO_FIELD_NAME] = flatten_publications(doc)
+
+
+            if len(buffer) == BUFFER_SIZE:
+                yield from buffer
+                buffer = []
+
+        if len(buffer) > 0:
+            yield from buffer

--- a/plugins/rtx-kg2/uploader.py
+++ b/plugins/rtx-kg2/uploader.py
@@ -1,0 +1,343 @@
+import pathlib
+
+import biothings, config
+from biothings.hub.dataload.uploader import ParallelizedSourceUploader
+from biothings.utils.storage import MergerStorage
+
+from .parser import load_data_file
+
+
+biothings.config_for_app(config)
+
+
+class RtxKg2Uploader(ParallelizedSourceUploader):
+    name = "rtx-kg2-edges-merged"
+    storage_class = MergerStorage
+
+    # todo metadata tbd
+    # __metadata__ = {}
+
+    def jobs(self):
+        data_path = pathlib.Path(self.data_folder).glob("**/*")
+        files = [file for file in data_path if file.is_file()]
+        return [(f,) for f in files]
+
+    def load_data(self, data_path):
+        self.logger.info("Processing data from %s", data_path)
+        return load_data_file(data_path)
+
+
+    # for edges with nodes information merged-in
+    @classmethod
+    def get_mapping(cls) -> dict:
+        mapping = {
+            "properties": {
+                "agent_type": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "domain_range_exclusion": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "long"
+                },
+                "kg2_ids": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "knowledge_level": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "object": {
+                    "properties": {
+                        "all_categories": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "all_names": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "category": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "equivalent_curies": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "iri": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "publications": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    }
+                },
+                "predicate": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "primary_knowledge_source": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "publications": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "publications_info": {
+                    "properties": {
+                        "object_score": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "pmid": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "publication_date": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "sentence": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "subject_score": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    }
+                },
+                "qualified_object_aspect": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "qualified_object_direction": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "qualified_predicate": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "subject": {
+                    "properties": {
+                        "all_categories": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "all_names": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "category": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "equivalent_curies": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "iri": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "publications": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return mapping


### PR DESCRIPTION
This pull request adds parser and uploader for **merged** `rtx-kg2` edges.

1. The parser flattens `publications_info` field, if exists, from a dictionary with unique `pmid:<unique id>` as keys, to a list with `pmid` field in each elements
2. The uploader has an updated `ES` mapping for edges merged with nodes.