### PR TITLE
Add get_normalized_nodes endpoint to nodenorm API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+### Start Default Settings ###
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -20,6 +22,7 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -38,14 +41,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
 *.cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -55,6 +61,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -67,28 +74,71 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
-
-# PyCharm
-.idea/
-
-# macOS
-.DS_Store
 
 # Jupyter Notebook
 .ipynb_checkpoints
 
-# pyenv
-.python-version
+# IPython
+profile_default/
+ipython_config.py
 
-# celery beat schedule file
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
 celerybeat-schedule
+celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -109,6 +159,56 @@ pendingenv/
 
 # mypy
 .mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+### End Default Settings ###
+
+# macOS
+.DS_Store
 
 # vim
 .sw*
@@ -116,6 +216,11 @@ pendingenv/
 # test folder for web testing
 config_test/
 
+# SSH keys
 ssh_host_key*
 
+# pending.api configuration settings
 config.py
+
+# biothings hub dataplugin folders
+*.biothings_hub/

--- a/config_web/nodenorm.py
+++ b/config_web/nodenorm.py
@@ -1,6 +1,10 @@
+from biothings.web.settings.default import APP_LIST
+
 ES_HOST = "http://localhost:9200"
 ES_INDEX = "pending-nodenorm"
 ES_DOC_TYPE = "node"
+
+APP_LIST = [(r"/{pre}/{ver}/get_normalized_nodes?", "web.handlers.NormalizedNodesHandler"), *APP_LIST]
 
 API_PREFIX = "nodenorm"
 API_VERSION = ""

--- a/plugins/nodenorm/README.md
+++ b/plugins/nodenorm/README.md
@@ -1,6 +1,6 @@
 ## pending-nodenorm
 
-Hosted API of the nodenorm data provided by [RENCI](https://stars.renci.org/var/babel_outputs/2025jan23/compendia/)
+Hosted API of the nodenorm data provided by [RENCI](https://stars.renci.org/var/babel_outputs/2025mar31/compendia/)
 
 File list (with smaller chunk files removed) as of March 12th 2025
 
@@ -89,5 +89,66 @@ umls.txt                                           24-Jan-2025 07:11           2
     "extra_index_settings": {
         "auto_expand_replicas": "0-all"
     }
+}
+```
+
+
+### API
+
+In order to validate elasticsearch as a backend, we want to mimic parts of the current nodenorm API
+to compare the performance between the two. We currently want to support the following endpoints:
+
+
+* `get_normalized_nodes` (GET | POST)
+
+##### JSONSchema for `get_normalized_nodes`
+
+```JSON
+"CurieList": {
+  "properties": {
+    "curies": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "minItems": 1,
+      "title": "List of CURIEs to normalize"
+    },
+    "conflate": {
+      "type": "boolean",
+      "title": "Whether to apply gene/protein conflation",
+      "default": true
+    },
+    "description": {
+      "type": "boolean",
+      "title": "Whether to return CURIE descriptions when possible",
+      "default": false
+    },
+    "drug_chemical_conflate": {
+      "type": "boolean",
+      "title": "Whether to apply drug/chemical conflation",
+      "default": false
+    },
+    "individual_types": {
+      "type": "boolean",
+      "title": "Whether to return individual types for equivalent identifiers",
+      "default": false
+    }
+  },
+  "type": "object",
+  "required": [
+    "curies"
+  ],
+  "title": "CurieList",
+  "description": "Curie list input model",
+  "example": {
+    "curies": [
+      "MESH:D014867",
+      "NCIT:C34373"
+    ],
+    "conflate": true,
+    "description": false,
+    "drug_chemical_conflate": false
+  }
 }
 ```

--- a/plugins/nodenorm/parse.py
+++ b/plugins/nodenorm/parse.py
@@ -1,9 +1,32 @@
 import json
+import pathlib
+import sqlite3
+
+from typing import Union
+
+drug_chemical_identifier_files = [
+    "Drug.txt",
+    "ChemicalEntity.txt",
+    "SmallMolecule.txt",
+    "ComplexMolecularMixture.txt",
+    "MolecularMixture.txt",
+    "Protein.txt",
+]
 
 
-def load_data_file(input_file: str):
+gene_protein_identifier_files = ["Protein.txt", "Gene.txt"]
+
+
+def load_data_file(input_file: str, conflation_database: Union[str, pathlib.Path]):
+    connection = sqlite3.connect(str(conflation_database))
+    if input_file.name in drug_chemical_identifier_files or input_file.name in gene_protein_identifier_files:
+        _load_data_file_with_conflations(input_file, connection)
+    else:
+        _load_data_file(input_file)
+
+
+def _load_data_file(input_file: Union[str, pathlib.Path]):
     with open(input_file, encoding="utf-8") as file_handle:
-
         buffer = []
         line = file_handle.readline()
         while line:
@@ -14,6 +37,7 @@ def load_data_file(input_file: str):
             except (TypeError, ValueError):
                 doc["ic"] = 0.0
             buffer.append(doc)
+            doc["identifiers"]["c"] = {"gp": None, "cd": None}
 
             if len(buffer) >= 1024:
                 yield from buffer
@@ -23,3 +47,56 @@ def load_data_file(input_file: str):
         if len(buffer) > 0:
             yield from buffer
             buffer = []
+
+
+def _load_data_file_with_conflations(input_file: Union[str, pathlib.Path], conflation_database: sqlite3.Connection):
+    with open(input_file, encoding="utf-8") as file_handle:
+        buffer = []
+        canonical_identifiers = []
+        line = file_handle.readline()
+        while line:
+            doc = json.loads(line)
+            canonical_identifier = doc["identifiers"][0]["i"]
+            canonical_identifiers.append(canonical_identifier)
+            doc["_id"] = canonical_identifier
+            try:
+                doc["ic"] = float(doc["ic"])
+            except (TypeError, ValueError):
+                doc["ic"] = 0.0
+            buffer.append(doc)
+            doc["identifiers"]["c"] = {"gp": None, "cd": None}
+
+            if len(buffer) >= 1024:
+                buffer = _update_buffer_with_conflations(buffer, canonical_identifiers, conflation_database)
+                yield from buffer
+                buffer = []
+                canonical_identifiers = []
+
+            line = file_handle.readline()
+
+        if len(buffer) > 0:
+            buffer = _update_buffer_with_conflations(buffer, canonical_identifiers, conflation_database)
+            yield from buffer
+
+
+def _update_buffer_with_conflations(
+    buffer: list[dict], canonical_identifiers: list[str], conflation_database: sqlite3.Connection
+) -> list[str]:
+    """
+    Batch updates the buffer documents with the conflation identifiers found
+    """
+    identifiers = [{"canonical_identifier": identifier for identifier in canonical_identifiers}]
+    identifier_results = conflation_database.executemany(
+        "SELECT identifiers, type FROM conflations WHERE conflation = VALUES(:canonical_identifier)", identifiers
+    )
+
+    for document, conflation_results in zip(buffer, identifier_results.fetchall()):
+        if conflation_results is not None:
+            identifiers = conflation_results[0].split(",").strip()
+            conflation_type = conflation_results[1]
+
+            if conflation_type == "GeneProtein":
+                document["identifiers"]["c"]["gp"] = identifiers
+            elif conflation_type == "DrugChemical":
+                document["identifiers"]["c"]["dc"] = identifiers
+    return buffer

--- a/plugins/nodenorm/uploader.py
+++ b/plugins/nodenorm/uploader.py
@@ -1,10 +1,12 @@
 import pathlib
+from typing import Union
 
 import biothings, config
 from biothings.hub.dataload.uploader import ParallelizedSourceUploader
 from biothings.utils.storage import MergerStorage
 
 from .parse import load_data_file
+from .dumper import NODENORM_FILE_COLLECTION, NODENORM_BIG_FILE_COLLECTION, BASE_URL, CONFLATION_LOOKUP_DATABASE
 
 
 biothings.config_for_app(config)
@@ -13,20 +15,18 @@ biothings.config_for_app(config)
 class NodeNormUploader(ParallelizedSourceUploader):
     name = "nodenorm"
     storage_class = MergerStorage
-    __metadata__ = {
-        "src_meta": {
-            "url": "https://stars.renci.org/var/babel_outputs/2025jan23/compendia",
-        }
-    }
+    __metadata__ = {"src_meta": {"url": BASE_URL}}
 
-    def jobs(self):
+    def jobs(self) -> list[tuple]:
         data_path = pathlib.Path(self.data_folder).glob("**/*")
-        files = [file for file in data_path if file.is_file()]
-        return [(f,) for f in files]
+        file_names = [*NODENORM_FILE_COLLECTION, *NODENORM_BIG_FILE_COLLECTION.keys()]
+        files = [data_path.joinpath(file) for file in file_names]
+        conflation_database = data_path.joinpath(CONFLATION_LOOKUP_DATABASE)
+        return [(f, conflation_database) for f in files]
 
-    def load_data(self, data_path):
+    def load_data(self, data_path: Union[str, pathlib.Path], conflation_database: Union[str, pathlib.Path]):
         self.logger.info("Processing data from %s", data_path)
-        return load_data_file(data_path)
+        return load_data_file(data_path, conflation_database)
 
     @classmethod
     def get_mapping(cls) -> dict:
@@ -47,6 +47,7 @@ class NodeNormUploader(ParallelizedSourceUploader):
                     },
                     "d": {"type": "text"},
                     "t": {"normalizer": "keyword_lowercase_normalizer", "type": "keyword"},
+                    "c": {"properties": {"gp": {"type": "keyword"}, "cd": {"type": "keyword"}}},
                 }
             },
             "preferred_name": {"type": "text"},

--- a/plugins/nodenorm/uploader.py
+++ b/plugins/nodenorm/uploader.py
@@ -18,10 +18,9 @@ class NodeNormUploader(ParallelizedSourceUploader):
     __metadata__ = {"src_meta": {"url": BASE_URL}}
 
     def jobs(self) -> list[tuple]:
-        data_path = pathlib.Path(self.data_folder).glob("**/*")
         file_names = [*NODENORM_FILE_COLLECTION, *NODENORM_BIG_FILE_COLLECTION.keys()]
-        files = [data_path.joinpath(file) for file in file_names]
-        conflation_database = data_path.joinpath(CONFLATION_LOOKUP_DATABASE)
+        files = [pathlib.Path(self.data_folder).joinpath(file) for file in file_names]
+        conflation_database = pathlib.Path(self.data_folder).joinpath(CONFLATION_LOOKUP_DATABASE)
         return [(f, conflation_database) for f in files]
 
     def load_data(self, data_path: Union[str, pathlib.Path], conflation_database: Union[str, pathlib.Path]):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,12 @@
 biothings[web_extra]==0.12.5
 GitPython>=3.1.43
 
-# for annotator handler
+# annotator handler
 biothings_client>=0.3.0
+
+# nodenorm web handler
+bmt>=1.4.5
+
+# testing
+docker
+jsonlines

--- a/tests/handlers/test_nodenorm.py
+++ b/tests/handlers/test_nodenorm.py
@@ -38,7 +38,7 @@ class TestNodeNormalizationHandler(AsyncHTTPTestCase):
         """
         normalized_nodes_endpoint = r"/nodenorm/get_normalized_nodes"
         url = self.get_url(normalized_nodes_endpoint)
-        body = json.dumps({ "curie": [ "MESH:D014867", "NCIT:C34373"] })
+        body = json.dumps({"curie": ["MESH:D014867", "NCIT:C34373"]})
         headers = {"Content-Type": "application/json"}
 
         http_client = AsyncHTTPClient()
@@ -47,50 +47,61 @@ class TestNodeNormalizationHandler(AsyncHTTPTestCase):
 
         expected_body = {
             "MESH:D014867": {
-                "id": {
-                    "identifier": "CHEBI:15377"
-                },
                 "equivalent_identifiers": [
                     {
-                        "identifier": "CHEBI:15377"
+                        "identifier": "CHEBI:15377",
+                        "label": "water",
                     },
                     {
-                        "identifier": "UNII:059QF0KO0R"
+                        "identifier": "UNII:059QF0KO0R",
+                        "label": "WATER",
                     },
                     {
-                        "identifier": "PUBCHEM.COMPOUND:962"
+                        "identifier": "PUBCHEM.COMPOUND:962",
+                        "label": "Water",
                     },
                     {
-                        "identifier": "CHEMBL.COMPOUND:CHEMBL1098659"
+                        "identifier": "CHEMBL.COMPOUND:CHEMBL1098659",
+                        "label": "WATER",
                     },
                     {
-                        "identifier": "DRUGBANK:DB09145"
+                        "identifier": "DRUGBANK:DB09145",
+                        "label": "Water",
                     },
                     {
-                        "identifier": "MESH:D014867"
+                        "identifier": "MESH:D014867",
+                        "label": "Water",
                     },
                     {
-                        "identifier": "CAS:231-791-2"
+                        "identifier": "CAS:231-791-2",
                     },
                     {
-                        "identifier": "CAS:7732-18-5"
+                        "identifier": "CAS:7732-18-5",
                     },
                     {
-                        "identifier": "HMDB:HMDB0002111"
+                        "identifier": "HMDB:HMDB0002111",
+                        "label": "Water",
                     },
                     {
-                        "identifier": "KEGG.COMPOUND:C00001"
+                        "identifier": "KEGG.COMPOUND:C00001",
+                        "label": "H2O",
                     },
                     {
-                        "identifier": "INCHIKEY:XLYOFNOQVPJJNP-UHFFFAOYSA-N"
+                        "identifier": "INCHIKEY:XLYOFNOQVPJJNP-UHFFFAOYSA-N",
                     },
                     {
-                        "identifier": "UMLS:C0043047"
+                        "identifier": "UMLS:C0043047",
+                        "label": "water",
                     },
                     {
-                        "identifier": "RXCUI:11295"
-                    }
+                        "identifier": "RXCUI:11295",
+                    },
                 ],
+                "id": {
+                    "identifier": "CHEBI:15377",
+                    "label": "Water",
+                },
+                "information_content": 47.7,
                 "type": [
                     "biolink:SmallMolecule",
                     "biolink:MolecularEntity",
@@ -100,69 +111,75 @@ class TestNodeNormalizationHandler(AsyncHTTPTestCase):
                     "biolink:ChemicalEntityOrGeneOrGeneProduct",
                     "biolink:ChemicalEntityOrProteinOrPolypeptide",
                     "biolink:NamedThing",
-                    "biolink:PhysicalEssenceOrOccurrent"
+                    "biolink:PhysicalEssenceOrOccurrent",
                 ],
-                "information_content": 47.7
             },
             "NCIT:C34373": {
-                "id": {
-                    "identifier": "MONDO:0004976"
-                },
                 "equivalent_identifiers": [
                     {
-                        "identifier": "MONDO:0004976"
+                        "identifier": "MONDO:0004976",
+                        "label": "amyotrophic lateral sclerosis",
                     },
                     {
-                        "identifier": "DOID:332"
+                        "identifier": "DOID:332",
+                        "label": "amyotrophic lateral sclerosis",
                     },
                     {
-                        "identifier": "orphanet:803"
+                        "identifier": "orphanet:803",
                     },
                     {
-                        "identifier": "UMLS:C0002736"
+                        "identifier": "UMLS:C0002736",
+                        "label": "Amyotrophic Lateral Sclerosis",
                     },
                     {
-                        "identifier": "MESH:D000690"
+                        "identifier": "MESH:D000690",
+                        "label": "Amyotrophic Lateral Sclerosis",
                     },
                     {
-                        "identifier": "MEDDRA:10002026"
+                        "identifier": "MEDDRA:10002026",
                     },
                     {
-                        "identifier": "MEDDRA:10052889"
+                        "identifier": "MEDDRA:10052889",
                     },
                     {
-                        "identifier": "NCIT:C34373"
+                        "identifier": "NCIT:C34373",
+                        "label": "Amyotrophic Lateral Sclerosis",
                     },
                     {
-                        "identifier": "SNOMEDCT:86044005"
+                        "identifier": "SNOMEDCT:86044005",
                     },
                     {
-                        "identifier": "medgen:274"
+                        "identifier": "medgen:274",
                     },
                     {
-                        "identifier": "icd11.foundation:1982355687"
+                        "identifier": "icd11.foundation:1982355687",
                     },
                     {
-                        "identifier": "ICD10:G12.21"
+                        "identifier": "ICD10:G12.21",
                     },
                     {
-                        "identifier": "ICD9:335.20"
+                        "identifier": "ICD9:335.20",
                     },
                     {
-                        "identifier": "KEGG.DISEASE:05014"
+                        "identifier": "KEGG.DISEASE:05014",
                     },
                     {
-                        "identifier": "HP:0007354"
-                    }
+                        "identifier": "HP:0007354",
+                        "label": "Amyotrophic lateral sclerosis",
+                    },
                 ],
+                "id": {
+                    "identifier": "MONDO:0004976",
+                    "label": "amyotrophic lateral sclerosis",
+                },
+                "information_content": 74.9,
                 "type": [
                     "biolink:Disease",
                     "biolink:DiseaseOrPhenotypicFeature",
                     "biolink:BiologicalEntity",
                     "biolink:ThingWithTaxon",
-                    "biolink:NamedThing"
+                    "biolink:NamedThing",
                 ],
-                "information_content": 74.9
-            }
+            },
         }
         assert expected_body == body

--- a/tests/handlers/test_nodenorm.py
+++ b/tests/handlers/test_nodenorm.py
@@ -1,0 +1,168 @@
+"""
+Tests for mocking the nodenorm handling
+"""
+
+import json
+
+import tornado
+from tornado.testing import AsyncHTTPTestCase, gen_test
+from tornado.httpclient import AsyncHTTPClient
+
+from web.handlers import EXTRA_HANDLERS
+from web.application import PendingAPI
+from web.settings.configuration import load_configuration
+
+
+class TestNodeNormalizationHandler(AsyncHTTPTestCase):
+
+    def get_app(self) -> tornado.web.Application:
+        configuration = load_configuration("config_web/nodenorm.py")
+        configuration.ES_INDICES = {configuration.ES_DOC_TYPE: "nodenorm_20250507_4ibdxry7"}
+        configuration.ES_HOST = "http://su10:9200"
+        app_handlers = EXTRA_HANDLERS
+        app_settings = {"static_path": "static"}
+        application = PendingAPI.get_app(configuration, app_settings, app_handlers)
+        return application
+
+    @gen_test(timeout=0.50)
+    def test_node_normalization(self):
+        """
+        Tests the plugin metadata responses
+
+        Accumulates all of the API's found through the /api/list endpoint
+        and then test each one to ensure that the metadata structure is consistent
+        across all endpoints
+
+        Also ensures that we correctly handle SMARTAPI identifier integration
+        for plugins that have and don't have it when reporting the metadata
+        """
+        normalized_nodes_endpoint = r"/nodenorm/get_normalized_nodes"
+        url = self.get_url(normalized_nodes_endpoint)
+        body = json.dumps({ "curie": [ "MESH:D014867", "NCIT:C34373"] })
+        headers = {"Content-Type": "application/json"}
+
+        http_client = AsyncHTTPClient()
+        response = yield http_client.fetch(url, self.stop, method="POST", headers=headers, body=body, request_timeout=0)
+        body = json.loads(response.body.decode("utf-8"))
+
+        expected_body = {
+            "MESH:D014867": {
+                "id": {
+                    "identifier": "CHEBI:15377"
+                },
+                "equivalent_identifiers": [
+                    {
+                        "identifier": "CHEBI:15377"
+                    },
+                    {
+                        "identifier": "UNII:059QF0KO0R"
+                    },
+                    {
+                        "identifier": "PUBCHEM.COMPOUND:962"
+                    },
+                    {
+                        "identifier": "CHEMBL.COMPOUND:CHEMBL1098659"
+                    },
+                    {
+                        "identifier": "DRUGBANK:DB09145"
+                    },
+                    {
+                        "identifier": "MESH:D014867"
+                    },
+                    {
+                        "identifier": "CAS:231-791-2"
+                    },
+                    {
+                        "identifier": "CAS:7732-18-5"
+                    },
+                    {
+                        "identifier": "HMDB:HMDB0002111"
+                    },
+                    {
+                        "identifier": "KEGG.COMPOUND:C00001"
+                    },
+                    {
+                        "identifier": "INCHIKEY:XLYOFNOQVPJJNP-UHFFFAOYSA-N"
+                    },
+                    {
+                        "identifier": "UMLS:C0043047"
+                    },
+                    {
+                        "identifier": "RXCUI:11295"
+                    }
+                ],
+                "type": [
+                    "biolink:SmallMolecule",
+                    "biolink:MolecularEntity",
+                    "biolink:ChemicalEntity",
+                    "biolink:PhysicalEssence",
+                    "biolink:ChemicalOrDrugOrTreatment",
+                    "biolink:ChemicalEntityOrGeneOrGeneProduct",
+                    "biolink:ChemicalEntityOrProteinOrPolypeptide",
+                    "biolink:NamedThing",
+                    "biolink:PhysicalEssenceOrOccurrent"
+                ],
+                "information_content": 47.7
+            },
+            "NCIT:C34373": {
+                "id": {
+                    "identifier": "MONDO:0004976"
+                },
+                "equivalent_identifiers": [
+                    {
+                        "identifier": "MONDO:0004976"
+                    },
+                    {
+                        "identifier": "DOID:332"
+                    },
+                    {
+                        "identifier": "orphanet:803"
+                    },
+                    {
+                        "identifier": "UMLS:C0002736"
+                    },
+                    {
+                        "identifier": "MESH:D000690"
+                    },
+                    {
+                        "identifier": "MEDDRA:10002026"
+                    },
+                    {
+                        "identifier": "MEDDRA:10052889"
+                    },
+                    {
+                        "identifier": "NCIT:C34373"
+                    },
+                    {
+                        "identifier": "SNOMEDCT:86044005"
+                    },
+                    {
+                        "identifier": "medgen:274"
+                    },
+                    {
+                        "identifier": "icd11.foundation:1982355687"
+                    },
+                    {
+                        "identifier": "ICD10:G12.21"
+                    },
+                    {
+                        "identifier": "ICD9:335.20"
+                    },
+                    {
+                        "identifier": "KEGG.DISEASE:05014"
+                    },
+                    {
+                        "identifier": "HP:0007354"
+                    }
+                ],
+                "type": [
+                    "biolink:Disease",
+                    "biolink:DiseaseOrPhenotypicFeature",
+                    "biolink:BiologicalEntity",
+                    "biolink:ThingWithTaxon",
+                    "biolink:NamedThing"
+                ],
+                "information_content": 74.9
+            }
+        }
+        assert expected_body == body

--- a/web/handlers/__init__.py
+++ b/web/handlers/__init__.py
@@ -2,13 +2,8 @@
 Dynamic Web Pages
 """
 
-import json
 import logging
 import os
-import types
-
-import tornado.httpclient
-import tornado.web
 
 
 from config_web import (
@@ -21,8 +16,9 @@ from config_web import (
 from .annotator import AnnotatorHandler
 from .api import ApiListHandler
 from .diseases import DiseasesHandler
-from .graph import GraphQueryHandler  # Don't remove: It's used to build handlers from API_LIST
-from .ngd import SemmedNGDHandler  # Don't remove: It's used to build handlers from API_LIST
+from .graph import GraphQueryHandler  # noqa # pylint: disable=unused-import
+from .ngd import SemmedNGDHandler  # noqa # pylint: disable=unused-import
+from .nodenorm import NormalizedNodesHandler  # noqa # pylint: disable=unused-import
 from .status import StatusDefaultHandler
 from .version import VersionHandler
 

--- a/web/handlers/metadata.py
+++ b/web/handlers/metadata.py
@@ -26,10 +26,8 @@ class PendingMetadataSourceHandler(MetadataSourceHandler):
         """
         config = self.biothings.config
 
-        if hasattr(config, 'SMARTAPI_ID'):
-            smartapi_mapping = {
-                "id": getattr(config, "SMARTAPI_ID", "")
-            }
+        if hasattr(config, "SMARTAPI_ID"):
+            smartapi_mapping = {"id": getattr(config, "SMARTAPI_ID", "")}
             _meta["smartapi"] = smartapi_mapping
 
         return _meta

--- a/web/handlers/nodenorm.py
+++ b/web/handlers/nodenorm.py
@@ -405,7 +405,7 @@ class NormalizedNodesHandler(BaseAPIHandler):
         curies = [c.upper() for c in curies]
         curie_order = {curie: index for index, curie in enumerate(curies)}
         curie_terms_query = {"bool": {"filter": [{"terms": {"identifiers.i": curies}}]}}
-        source_fields = ["identifiers.i", "type", "ic"]
+        source_fields = ["identifiers", "type", "ic"]
         index = self.biothings.elasticsearch.metadata.indices["node"]
         term_search_result = await self.biothings.elasticsearch.async_client.search(
             query=curie_terms_query, index=index, size=len(curies), source_includes=source_fields
@@ -419,8 +419,6 @@ class NormalizedNodesHandler(BaseAPIHandler):
                 identifiers_set.add(identifier.get("i", None))
         malformed_curies = set(curies) - identifiers_set
         curies = [c for c in curies if c not in malformed_curies]
-
-        breakpoint()
 
         nodes = []
         for input_curie, result in zip(curies, term_search_result.body["hits"]["hits"]):

--- a/web/handlers/nodenorm.py
+++ b/web/handlers/nodenorm.py
@@ -1,0 +1,509 @@
+import dataclasses
+import logging
+import os
+import time
+from typing import Union
+
+import bmt as bmt
+
+from biothings.web.handlers import BaseAPIHandler
+from biothings.web.settings.default import COMMON_KWARGS
+from tornado.web import HTTPError
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+BIOLINK_VERSION = os.getenv("BIOLINK_VERSION", "v4.2.2")
+BIOLINK_MODEL_URL = f"https://raw.githubusercontent.com/biolink/biolink-model/{BIOLINK_VERSION}/biolink-model.yaml"
+toolkit = bmt.Toolkit(BIOLINK_MODEL_URL)
+
+
+defaultconfig = {
+    "preferred_name_boost_prefixes": {
+        "biolink:ChemicalEntity": [
+            "DRUGBANK",
+            "DrugCentral",
+            "CHEBI",
+            "MESH",
+            "CHEMBL.COMPOUND",
+            "GTOPDB",
+            "HMDB",
+            "RXCUI",
+            "PUBCHEM.COMPOUND",
+        ]
+    },
+    "demote_labels_longer_than": 15,
+}
+
+
+@dataclasses.dataclass
+class NormalizedNode:
+    curie: str
+    canonical_identifier: str
+    identifiers: list[str]
+    information_content: float
+    types: list[str]
+
+
+class NormalizedNodesHandler(BaseAPIHandler):
+    """
+    Mirror implementation to the renci implementation found at
+    https://nodenormalization-sri.renci.org/docs
+
+    We intend to mirror the /get_normalized_nodes endpoint
+    """
+
+    name = "normalizednodes"
+
+    async def get(self, *args, **kwargs):
+        normalized_curies = self.args.get("curie", [])
+        conflate = self.args.get(
+            "conflate", False
+        )  # Original defaults to True, TODO revert once conflation is supported
+        drug_chemical_conflate = self.args.get("drug_chemical_conflate", False)
+        description = self.args.get("description", False)
+        individual_types = self.args.get("individual_types", False)
+
+        if len(normalized_curies) == 0:
+            raise HTTPError(
+                detail="Missing curie argument, there must be at least one curie to normalize", status_code=400
+            )
+
+        normalized_nodes = await self.get_normalized_nodes(
+            normalized_curies,
+            conflate,
+            drug_chemical_conflate,
+            include_descriptions=description,
+            include_individual_types=individual_types,
+        )
+
+        # If curie contains at least one entry, then the only way normalized_nodes could be blank
+        # would be if an error occurred during processing.
+        if not normalized_nodes:
+            raise HTTPError(detail="Error occurred during processing.", status_code=500)
+
+        self.finish(normalized_nodes)
+
+    async def post(self):
+        """
+        Returns the equivalent identifiers and semantic types for the curie(s)
+
+        Example body
+        {
+          "curies": [
+            "MESH:D014867",
+            "NCIT:C34373"
+          ]
+        }
+        We don't currently support the following flags that renci does:
+        >>> conflate
+        >>> drug_chemical_conflate
+        >>> description
+
+        Example output
+        {
+          "MESH:D014867": {
+            "id": {
+              "identifier": "CHEBI:15377",
+              "label": "Water"
+            },
+            "equivalent_identifiers": [
+              {
+                "identifier": "CHEBI:15377",
+                "label": "water"
+              },
+              ...
+            ],
+            "type": [
+              "biolink:SmallMolecule",
+              "biolink:MolecularEntity",
+              "biolink:ChemicalEntity",
+              "biolink:PhysicalEssence",
+              "biolink:ChemicalOrDrugOrTreatment",
+              "biolink:ChemicalEntityOrGeneOrGeneProduct",
+              "biolink:ChemicalEntityOrProteinOrPolypeptide",
+              "biolink:NamedThing",
+              "biolink:PhysicalEssenceOrOccurrent"
+            ],
+            "information_content": 47.7
+          },
+          "NCIT:C34373": {
+            "id": {
+              "identifier": "MONDO:0004976",
+              "label": "amyotrophic lateral sclerosis"
+            },
+            "equivalent_identifiers": [
+              {
+                "identifier": "MONDO:0004976",
+                "label": "amyotrophic lateral sclerosis"
+              },
+              ...
+            ],
+            "type": [
+              "biolink:Disease",
+              "biolink:DiseaseOrPhenotypicFeature",
+              "biolink:BiologicalEntity",
+              "biolink:ThingWithTaxon",
+              "biolink:NamedThing"
+            ],
+            "information_content": 74.9
+          }
+        }
+        """
+        normalization_curies = self.args_json.get("curie", [])
+        conflate = self.args.get(
+            "conflate", False
+        )  # Original defaults to True, TODO revert once conflation is supported
+        drug_chemical_conflate = self.args_json.get("drug_chemical_conflate", False)
+        description = self.args_json.get("description", False)
+        individual_types = self.args_json.get("individual_types", False)
+
+        if len(normalization_curies) == 0:
+            raise HTTPError(
+                detail="Missing curie argument, there must be at least one curie to normalize", status_code=400
+            )
+
+        normalized_nodes = await self.get_normalized_nodes(
+            normalization_curies,
+            conflate,
+            drug_chemical_conflate,
+            include_descriptions=description,
+            include_individual_types=individual_types,
+        )
+
+        # If curie contains at least one entry, then the only way normalized_nodes could be blank
+        # would be if an error occurred during processing.
+        if not normalized_nodes:
+            raise HTTPError(detail="Error occurred during processing.", status_code=500)
+
+        self.finish(normalized_nodes)
+
+    async def get_normalized_nodes(
+        self,
+        curies: list[str],
+        conflate_gene_protein: bool = False,
+        conflate_chemical_drug: bool = False,
+        include_descriptions: bool = False,
+        include_individual_types: bool = False,
+    ) -> dict:
+        start_time = time.perf_counter_ns()
+
+        conflations = {
+            "GeneProtein": conflate_gene_protein,
+            "DrugChemical": conflate_chemical_drug,
+        }
+
+        nodes = await self._lookup_curie_metadata(curies, conflations)
+
+        normal_nodes = {}
+        for input_curie, aggregate_node in zip(curies, nodes):
+            normal_node = await self.create_normalized_node(
+                aggregate_node,
+                include_descriptions=include_descriptions,
+                include_individual_types=include_individual_types,
+                conflations=conflations,
+            )
+            normal_nodes[input_curie] = normal_node
+
+        end_time = time.perf_counter_ns()
+        logger.info(
+            (
+                f"Normalized {len(curies)} nodes in {(end_time - start_time)/1_000_000:.2f} ms with arguments "
+                f"(curies={curies}, conflate_gene_protein={conflate_gene_protein}, conflate_chemical_drug={conflate_chemical_drug}, "
+                f"include_descriptions={include_descriptions}, include_individual_types={include_individual_types})"
+            )
+        )
+        return normal_nodes
+
+    async def create_normalized_node(
+        self,
+        aggregate_node: NormalizedNode,
+        include_descriptions: bool = True,
+        include_individual_types: bool = False,
+        conflations: dict = None,
+    ) -> dict:
+        """
+        Construct the output format given the aggregated node data
+        from elasticsearch
+        """
+        normal_node = {}
+
+        # It's possible that we didn't find a canonical_id
+        if aggregate_node.canonical_identifier is None:
+            return None
+
+        if conflations is None:
+            conflations = {}
+
+        # If we have 'None' in the equivalent IDs, skip it so we don't confuse things further down the line.
+        if None in aggregate_node.identifiers:
+            logging.warning(
+                "Filtering none-type values for canonical identifier {%s} among equivalent identifiers [%s]",
+                aggregate_node.canonical_identifier,
+                aggregate_node.identifiers,
+            )
+            aggregate_node.identifiers = [eqid for eqid in aggregate_node.identifiers if eqid is not None]
+            if not aggregate_node.identifiers:
+                logging.warning(
+                    "Only discovered none-type values for canonical identifier {%s} among filtered equivalent identifiers [%s]",
+                    aggregate_node.canonical_identifier,
+                    aggregate_node.identifiers,
+                )
+                return None
+
+        # If we have 'None' in the canonical types, something went horribly wrong (specifically: we couldn't
+        # find the type information for all the eqids for this clique). Return None.
+        if None in aggregate_node.types:
+            logging.error(
+                "No types found for canonical identifier {%s} among types [%s]",
+                aggregate_node.canonical_identifier,
+                aggregate_node.types,
+            )
+            return None
+
+        # OK, now we should have id's in the format [ {"i": "MONDO:12312", "l": "Scrofula"}, {},...]
+
+        # As per https://github.com/TranslatorSRI/Babel/issues/158, we select the first label from any
+        # identifier _except_ where one of the types is in preferred_name_boost_prefixes, in which case
+        # we prefer the prefixes listed there.
+        #
+        # This should perfectly replicate NameRes labels for non-conflated cliques, but it WON'T perfectly
+        # match conflated cliques. To do that, we need to run the preferred label algorithm on ONLY the labels
+        # for the FIRST clique of the conflated cliques with labels.
+        conflated_identifiers = any(conflations.values())
+        identifiers_with_labels = []
+        if not conflated_identifiers:
+            # No conflation. We just use the identifiers we've been given.
+            identifiers_with_labels = aggregate_node.identifiers
+        else:
+            logger.warning("No operation - skipping conflation logic")
+
+            # TODO Add support for conflation (gene-protion and chemical-drug)
+            # Modifies the equivalent identifiers and types for a canonical identifier
+
+        # We might get here without any labels, which is fine. At least we tried.
+
+        # At this point:
+        #   - eids will be the full list of all identifiers and labels in this clique.
+        #   - identifiers_with_labels is the list of identifiers and labels for the first subclique that has at least
+        #     one label.
+
+        # Note that types[canonical_id] goes from most specific to least specific, so we
+        # need to reverse it in order to apply preferred_name_boost_prefixes for the most
+        # specific type.
+        possible_labels = []
+        for bltype in aggregate_node.types[::-1]:
+            if bltype in defaultconfig["preferred_name_boost_prefixes"]:
+                # This is the most specific matching type, so we use this and then break.
+                possible_labels = list(
+                    map(
+                        lambda ident: ident.get("l", ""),
+                        self._sort_identifiers_with_boosted_prefixes(
+                            identifiers_with_labels, defaultconfig["preferred_name_boost_prefixes"][bltype]
+                        ),
+                    )
+                )
+
+                # Add in all the other labels -- we'd still like to consider them, but at a lower priority.
+                for eid in identifiers_with_labels:
+                    label = eid.get("l", "")
+                    if label not in possible_labels:
+                        possible_labels.append(label)
+
+                # Since this is the most specific matching type, we shouldn't do other (presumably higher-level)
+                # categories: so let's break here.
+                break
+
+        # Step 1.2. If we didn't have a preferred_name_boost_prefixes, just use the identifiers in their
+        # Biolink prefix order.
+        if not possible_labels:
+            possible_labels = map(lambda eid: eid.get("l", ""), identifiers_with_labels)
+
+        # Step 2. Filter out any suspicious labels.
+        filtered_possible_labels = [
+            l
+            for l in possible_labels
+            if l
+            and not l.startswith(
+                "CHEMBL"
+            )  # Ignore blank or empty names.  # Some CHEMBL names are just the identifier again.
+        ]
+
+        # Step 3. Filter out labels longer than defaultconfig['demote_labels_longer_than'], but only if there is at
+        # least one label shorter than this limit.
+        labels_shorter_than_limit = [
+            l for l in filtered_possible_labels if l and len(l) <= defaultconfig["demote_labels_longer_than"]
+        ]
+        if labels_shorter_than_limit:
+            filtered_possible_labels = labels_shorter_than_limit
+
+        # Note that the id will be from the equivalent ids, not the canonical_id.  This is to handle conflation
+        if len(filtered_possible_labels) > 0:
+            normal_node = {
+                "id": {"identifier": aggregate_node.identifiers[0]["i"], "label": filtered_possible_labels[0]}
+            }
+        else:
+            # Sometimes, nothing has a label :(
+            normal_node = {"id": {"identifier": aggregate_node.identifiers[0]["i"]}}
+
+        # Now that we've determined a label for this clique, we should never use identifiers_with_labels, possible_labels,
+        # or filtered_possible_labels after this point.
+
+        # if descriptions are enabled look for the first available description and use that
+        if include_descriptions:
+            descriptions = list(
+                map(
+                    lambda x: x[0],
+                    filter(lambda x: len(x) > 0, [eid["d"] for eid in aggregate_node.identifiers if "d" in eid]),
+                )
+            )
+            if len(descriptions) > 0:
+                normal_node["id"]["description"] = descriptions[0]
+
+        # now need to reformat the identifier keys.  It could be cleaner but we have to worry about if there is a label
+        normal_node["equivalent_identifiers"] = []
+        for eqid in aggregate_node.identifiers:
+            eq_item = {"identifier": eqid["i"]}
+            if "l" in eqid:
+                eq_item["label"] = eqid["l"]
+
+            # if descriptions is enabled and exist add them to each eq_id entry
+            if include_descriptions and "d" in eqid and len(eqid["d"]):
+                eq_item["description"] = eqid["d"][0]
+
+            # if individual types have been requested, add them too.
+            if include_individual_types and "t" in eqid:
+                eq_item["type"] = eqid["t"][-1]
+
+            normal_node["equivalent_identifiers"].append(eq_item)
+
+        normal_node["type"] = aggregate_node.types
+
+        # add the info content to the node if we got one
+        if aggregate_node.information_content is not None:
+            normal_node["information_content"] = aggregate_node.information_content
+
+        return normal_node
+
+    async def _lookup_curie_metadata(self, curies: list[str], conflations: dict) -> list[NormalizedNode]:
+        """
+        Handles the lookup process for the CURIE identifiers within our elasticsearch instance
+
+        Ported from the redis instance, this performs one set of batch lookup calls via a singular
+        terms query with the entire set of curies. Given the default maximum amount of terms queries
+        specified by index.max_terms_count is 65536 (2**16), we should be well under given our
+        usual maximum query size is ~3000 CURIE identifiers
+
+        We most also be careful though as the terms query is simply checking if any document
+        contains at least one of the terms. We expect a 1-1 matching for CURIE identifier to
+        document, so we can determine which terms were not found via set difference between the
+        returned document CURIE identifiers and the user provided set of CURIE identifiers
+        """
+        curie_set = {c.upper() for c in curies}
+        curie_terms_query = {"bool": {"filter": [{"terms": {"identifiers.i": list(curie_set)}}]}}
+        source_fields = ["identifiers.i", "type", "ic"]
+        index = self.biothings.elasticsearch.metadata.indices["node"]
+        term_search_result = await self.biothings.elasticsearch.async_client.search(
+            query=curie_terms_query, index=index, size=len(curie_set), source_includes=source_fields
+        )
+
+        nodes = []
+        for input_curie, result in zip(curie_set, term_search_result.body["hits"]["hits"]):
+            result_source = result.get("_source", {})
+            identifiers = result_source.get("identifiers", [])
+            biolink_type = result_source.get("type", None)
+
+            # Every equivalent identifier here has the same type.
+            for eqid in identifiers:
+                eqid.update({"t": biolink_type})
+
+            try:
+                canonical_identifier = identifiers[0].get("i", None)
+            except IndexError:
+                canonical_identifier = None
+            finally:
+                if canonical_identifier is None:
+                    continue
+            try:
+                information_content = round(float(result_source.get("ic", None)), 1)
+            except TypeError:
+                information_content = None
+
+            node_types = await self._populate_biolink_type_ancestors(biolink_type, canonical_identifier)
+
+            if any(conflations.values()):
+                conflation_identifiers = []
+                if conflations.get("GeneProtein", False):
+                    logger.warning("No operation - gene protein conflation not implemented yet")
+
+                if conflations.get("DrugChemical", False):
+                    logger.warning("No operation - chemical drug conflation not implemented yet")
+
+                # TODO Add support for conflation (gene-protion and chemical-drug)
+                # Modifies the equivalent identifiers and types for a canonical identifier
+
+            node = NormalizedNode(
+                curie=input_curie,
+                canonical_identifier=canonical_identifier,
+                identifiers=identifiers,
+                information_content=information_content,
+                types=node_types,
+            )
+            nodes.append(node)
+        return nodes
+
+    async def _populate_biolink_type_ancestors(
+        self, biolink_type: Union[str, list[str]], canonical_identifier: str
+    ) -> list[str]:
+        if not isinstance(biolink_type, list):
+            biolink_type = [biolink_type]
+
+        biolink_type_tree = []
+        for bltype in biolink_type:
+            if not bltype:
+                fallback_type = "biolink:NamedThing"
+                logging.error(
+                    "No type information found for '%s'. Default type set to -> '%s'",
+                    canonical_identifier,
+                    fallback_type,
+                )
+                biolink_type_tree.append(fallback_type)
+            else:
+                for anc in toolkit.get_ancestors(bltype):
+                    biolink_type_tree.append(toolkit.get_element(anc)["class_uri"])
+
+        # We need to remove `biolink:Entity` from the types returned.
+        # (See explanation at https://github.com/TranslatorSRI/NodeNormalization/issues/173)
+        try:
+            biolink_type_tree.remove("biolink:Entity")
+        except ValueError:
+            pass
+        return biolink_type_tree
+
+    def _sort_identifiers_with_boosted_prefixes(self, identifiers: list[str], prefixes: list[str]):
+        """
+        Given a list of identifiers (with `identifier` and `label` keys), sort them using
+        the following rules:
+        - Any identifier that has a prefix in prefixes is sorted based on its order in prefixes.
+        - Any identifier that does not have a prefix in prefixes is left in place.
+
+        Copied from https://github.com/TranslatorSRI/Babel/blob/0c3f3aed1bb1647f1ca101ba905dc241797fdfc9/src/babel_utils.py#L315-L333
+
+        :param identifiers: A list of identifiers to sort. This is a list of dictionaries
+            containing `identifier` and `label` keys, and possible others that we ignore.
+        :param prefixes: A list of prefixes, in the order in which they should be boosted.
+            We assume that CURIEs match these prefixes if they are in the form `{prefix}:...`.
+        :return: The list of identifiers sorted as described above.
+        """
+
+        # Thanks to JetBrains AI.
+        return sorted(
+            identifiers,
+            key=lambda identifier: (
+                prefixes.index(identifier["i"].split(":", 1)[0])
+                if identifier["i"].split(":", 1)[0] in prefixes
+                else len(prefixes)
+            ),
+        )

--- a/web/settings/configuration.py
+++ b/web/settings/configuration.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 class PendingAPIConfigModule(ConfigModule):
     override_mapping = None
 
-
     def __init__(self, config=None, parent=None, validators: tuple = (), **kwargs):
         super().__init__(config=config, parent=parent, validators=validators)
         self.module = config


### PR DESCRIPTION
Adds the preliminary integration of the nodenorm API into our elasticsearch backed backend system via the pending.api. This PR intends to support the usage of the `get_normalized_nodes` endpoint provided by [renci](https://nodenormalization-sri.renci.org/docs#/). 

Known issues / Improvements

- [x] Conflation
    - There are two compendia files we haven't ingested that handle the conflation aspect of nodenorm that can be found [here](https://stars.renci.org/var/babel_outputs/2025mar31/conflation/) This endpoint setups the same flags that nodenorm uses but the conflation logic hasn't been added. We could likely integrate it by ingesting the two additional compendia files and then either updating the index with the additional identifiers / create a separate index specifically for the conflation files

- [x] Debug why labels aren't appearing in output response    
- [x] Handling unknown / unavailable identifiers
    - I need to come up with a way of identifying CURIE identifiers provided by the user that don't exist. The renci nodenorm returns `null` for these and the logic should be simple but this does require additional logic due to the change in backend. We're currently querying elasticsearch via a terms query populated with the user provided CURIE identifiers
    
```JSON
{
    "bool": {
        "filter": [
            {
                "terms": {
                    "identifiers.i": [ ... ]
                }
            }
        ]
    }
}
```
However, this is searching the index for all of user provided queries at once. We expect there to be a 1-1 relationship between `identifer.i` and the CURIE, so all valid CURIE's should get a matching document in the order specified by the list. However invalid CURIE's return nothing and provides no indication that we failed, which will disrupt the order when returning results. I have a feeling I can resolve this using an aggregation but I need to tweak it slightly so we can properly handle unknown query results from users

The second one I think I can get done before merging this PR. The first one I just need to get done before the next relay in september. After I merge this I plan to integrate the comparison test between renci nodenorm and our nodenorm to see if any logic errors exist between the two when handling larger requests