### PR TITLE
Update babel to version date 2025sep1

### DIFF
--- a/plugins/nodenorm/dumper.py
+++ b/plugins/nodenorm/dumper.py
@@ -15,8 +15,11 @@ from biothings.utils.manager import JobManager
 
 logger = config.logger
 
-PRIOR_URL = ["https://stars.renci.org/var/babel_outputs/2025jan23"]
-BASE_URL = "https://stars.renci.org/var/babel_outputs/2025mar31/"
+PRIOR_URL = [
+    "https://stars.renci.org/var/babel_outputs/2025mar31/",
+    "https://stars.renci.org/var/babel_outputs/2025jan23",
+]
+BASE_URL = "https://stars.renci.org/var/babel_outputs/2025sep1/"
 
 
 NODENORM_FILE_COLLECTION = [


### PR DESCRIPTION
Files can be found [here](https://stars.renci.org/var/babel_outputs/2025sep1/)