### PR TITLE
Add nodenorm taxa information

### DIFF
--- a/web/handlers/nodenorm/normalized_nodes.py
+++ b/web/handlers/nodenorm/normalized_nodes.py
@@ -331,6 +331,7 @@ async def _lookup_curie_metadata(
                 information_content=-1.0,
                 identifiers=[],
                 types=[],
+                taxa=[],
             )
             nodes.append(node)
         else:


### PR DESCRIPTION
Adds the source field `taxa` from elasticsearch directly to the output response. New responses will include a `taxa` field as a list of CURIE's or an empty list depending on if the taxa information exists within elasticsearch

```JSON
{
  "NCBIGene:100732537": {
    "id": {
      "identifier": "NCBIGene:100732537",
      "label": "Ssuh2"
    },
    "equivalent_identifiers": [
      {
        "identifier": "NCBIGene:100732537",
        "label": "Ssuh2"
      }
    ],
    "type": [
      "biolink:Gene",
      "biolink:GeneOrGeneProduct",
      "biolink:GenomicEntity",
      "biolink:ChemicalEntityOrGeneOrGeneProduct",
      "biolink:PhysicalEssence",
      "biolink:OntologyClass",
      "biolink:BiologicalEntity",
      "biolink:ThingWithTaxon",
      "biolink:NamedThing",
      "biolink:PhysicalEssenceOrOccurrent",
      "biolink:MacromolecularMachineMixin"
    ],
    "taxa": [
      "NCBITaxon:10141"
    ]
  }
}
```